### PR TITLE
Amennyiben a lejátszó undefined range-et küld annak helyes kezelése

### DIFF
--- a/server/src/stremio/stream/stream.types.ts
+++ b/server/src/stremio/stream/stream.types.ts
@@ -14,7 +14,6 @@ import { StreamMediaTypeEnum } from '../enums/stream-media-type.enum';
 import { ParsedStreamIdSeries } from './pipe/stream-id.pipe';
 
 export enum RangeErrorEnum {
-  RANGE_NOT_DEFINED = 'range-not-defined',
   RANGE_NOT_SATISFIABLE = 'range-not-satisfiable',
   RANGE_MALFORMED = 'range-malformed',
 }


### PR DESCRIPTION
Az LG TV-k új frissítése érzékennyé vált erre a hibára és ezért a lejátszás nem indult el. A többi lejátszó hibamentesen működött (mobil, web és PC és MAC alkalmazás).