### PR TITLE
Filelist anime kategoriak hozzaadasa

### DIFF
--- a/server/src/trackers/adapters/filelist/filelist.adapter.ts
+++ b/server/src/trackers/adapters/filelist/filelist.adapter.ts
@@ -88,7 +88,6 @@ export class FilelistAdapter implements TrackerAdapter {
     switch (category) {
       case FilelistMovieCategoryEnum.SD:
       case FilelistMovieCategoryEnum.DVD:
-      case FilelistSeriesCategoryEnum.TV:
       case FilelistSeriesCategoryEnum.SD:
         return ResolutionEnum.R480P;
 
@@ -97,6 +96,8 @@ export class FilelistAdapter implements TrackerAdapter {
         return ResolutionEnum.R720P;
 
       case FilelistMovieCategoryEnum.BLU_RAY:
+      case FilelistMovieCategoryEnum.ANIME:
+      case FilelistSeriesCategoryEnum.ANIME:
         return ResolutionEnum.R1080P;
 
       case FilelistMovieCategoryEnum.UHD:

--- a/server/src/trackers/adapters/filelist/filelist.constants.ts
+++ b/server/src/trackers/adapters/filelist/filelist.constants.ts
@@ -3,9 +3,7 @@ import {
   FilelistSeriesCategoryEnum,
 } from './filelist.types';
 
-export const MOVIE_CATEGORY_FILTERS = Object.values(
-  FilelistMovieCategoryEnum
-);
+export const MOVIE_CATEGORY_FILTERS = Object.values(FilelistMovieCategoryEnum);
 export const SERIES_CATEGORY_FILTERS = Object.values(
   FilelistSeriesCategoryEnum,
 );

--- a/server/src/trackers/adapters/filelist/filelist.constants.ts
+++ b/server/src/trackers/adapters/filelist/filelist.constants.ts
@@ -3,7 +3,9 @@ import {
   FilelistSeriesCategoryEnum,
 } from './filelist.types';
 
-export const MOVIE_CATEGORY_FILTERS = Object.values(FilelistMovieCategoryEnum);
+export const MOVIE_CATEGORY_FILTERS = Object.values(
+  FilelistMovieCategoryEnum
+);
 export const SERIES_CATEGORY_FILTERS = Object.values(
   FilelistSeriesCategoryEnum,
 );

--- a/server/src/trackers/adapters/filelist/filelist.types.ts
+++ b/server/src/trackers/adapters/filelist/filelist.types.ts
@@ -1,5 +1,9 @@
 import { ParsedStreamSeries } from 'src/stremio/streams/type/parsed-stream-series.type';
 
+export enum FilelistCommonCategoryEnum {
+  ANIME = '24',
+}
+
 export enum FilelistMovieCategoryEnum {
   SD = '1',
   DVD = '2',
@@ -7,13 +11,14 @@ export enum FilelistMovieCategoryEnum {
   UHD = '6',
   BLU_RAY = '20',
   UHD_BLU_RAY = '26',
+  ANIME = FilelistCommonCategoryEnum.ANIME,
 }
 
 export enum FilelistSeriesCategoryEnum {
-  TV = '14',
   HD = '21',
   SD = '23',
   UHD = '27',
+  ANIME = FilelistCommonCategoryEnum.ANIME,
 }
 
 export type FilelistCategory =


### PR DESCRIPTION
- Hozzaadtam az ANIME kategoriat a filmekhez es a sorozatokhoz is (ez egy vegyes kategoria filelisten animeknek)
- kivettem a TV = '14' kategoriat a sorozatokbol, mert ezt multkor bentfelejtettem es nincs ilyen kategoria