### PR TITLE
nCore felbontás-/nyelvfelismerés, többévados tartomány-parszolás és mappa-alapú évadcsomagok javítása (LLM segítséggel, utólag átnézve, tesztelve)

### DIFF
--- a/server/app/modules/indexer_definitions/integrations/ncore.py
+++ b/server/app/modules/indexer_definitions/integrations/ncore.py
@@ -18,6 +18,8 @@ from app.modules.indexer_definitions.schemas.internal import (
     IndexerDefinitionTorrent,
 )
 from app.modules.media_attributes.constants import MediaAttributeKey
+from app.modules.media_attributes.parser import parse_torrent_name
+from app.modules.media_attributes.utils import resolve_attribute_ids
 
 
 class NcoreIndexerDefinition(BaseIndexerDefinition):
@@ -99,16 +101,14 @@ class NcoreIndexerDefinition(BaseIndexerDefinition):
 
         for torrent in data.get("results", []):
             category = torrent.get("category", "")
+            release_name = torrent.get("release_name", "")
             torrents.append(
                 IndexerDefinitionTorrent(
                     imdb_id=torrent.get("imdb_id"),
                     torrent_id=str(torrent["torrent_id"]),
                     seeders=int(torrent.get("seeders", 0)),
                     download_url=torrent["download_url"],
-                    attribute_ids=[
-                        self._resolve_language(category),
-                        self._resolve_resolution(category),
-                    ],
+                    attribute_ids=self._resolve_attribute_ids(category, release_name),
                 )
             )
 
@@ -178,12 +178,46 @@ class NcoreIndexerDefinition(BaseIndexerDefinition):
 
         return ids
 
-    def _resolve_resolution(self, category: str) -> str:
+    def _resolve_attribute_ids(self, category: str, release_name: str) -> list[str]:
+        """
+        Meghatározza egy nCore találat attribútum-azonosítóit (felbontás, nyelv, stb).
+
+        A parse_torrent_name() a tényleges release névből (pl. "...S05.1080p...")
+        pontosan kinyeri a felbontást és a nyelv(ek)et is, szemben a régi
+        megoldással, ami a nCore kategória-tagből (pl. "hdser_hun") csak egy
+        durva "hd" vs. "sd" megkülönböztetést tudott tenni - emiatt minden HD
+        kategóriájú találat 720p-nek látszott, még akkor is, ha valójában
+        1080p vagy akár 2160p volt.
+
+        A kategória-alapú heurisztikát csak tartalék (external_fallbacks)
+        megoldásként adjuk át a parse_torrent_name()-nek: azt csak akkor
+        használja fel egy adott kategóriához (pl. felbontás), ha a release
+        névben egyáltalán nem talál hozzá egyezést (pl. "Katicabogár...S04" -
+        itt a nCore kategória "_hun" végződése az egyetlen nyelvi jelzés).
+
+        Megjegyzés: csak external_fallbacks paramétert használunk (nem
+        use_fallbacks-ot), mivel az előbbi mind a GitHub main branch, mind a
+        publikált Docker image parse_torrent_name() függvényében elérhető -
+        a kettő implementációja @s4pp1/stremhu-source:latest-ben eltér a
+        GitHub main branch-től, és nem támogatja a use_fallbacks kwargot.
+        """
+        category_fallback_ids = [
+            self._resolve_resolution_from_category(category),
+            self._resolve_language_from_category(category),
+        ]
+        external_fallbacks = resolve_attribute_ids(category_fallback_ids)
+
+        parsed_attributes = parse_torrent_name(
+            release_name, external_fallbacks=external_fallbacks
+        )
+        return [attribute.id for attribute in parsed_attributes]
+
+    def _resolve_resolution_from_category(self, category: str) -> str:
         if "hd" in category:
             return MediaAttributeKey.R720P
         return MediaAttributeKey.R480P
 
-    def _resolve_language(self, category: str) -> str:
+    def _resolve_language_from_category(self, category: str) -> str:
         if "hun" in category:
             return MediaAttributeKey.HUN
         return MediaAttributeKey.ENG

--- a/server/app/modules/torrent_streams/utils/series_parser.py
+++ b/server/app/modules/torrent_streams/utils/series_parser.py
@@ -57,18 +57,22 @@ def _parse_season_list(s: str) -> list[int]:
         token = token.strip().lower()
         if not token:
             continue
-        # Strip optional "s" or "season" prefix in token (e.g. "s10" -> "10")
-        token = re.sub(r"^(?:seasons?|s)", "", token)
 
-        # Check if it is a range (e.g. "1-10")
-        range_match = re.match(r"^(\d{1,2})-(\d{1,2})$", token)
+        # Check if it is a range (e.g. "1-10", "01-04", "s01-s04", "01-s04").
+        # Both bounds may carry their own optional "s"/"season" prefix, since
+        # patterns like "S01-S04" or "Season 1 to S28" are common release
+        # naming conventions and each side is captured independently.
+        range_match = re.match(
+            r"^(?:seasons?|s)?(\d{1,2})-(?:seasons?|s)?(\d{1,2})$", token
+        )
         if range_match:
             seasons.extend(_expand_range(range_match.group(1), range_match.group(2)))
-        else:
-            # Single number
-            num_match = re.match(r"^(\d{1,2})$", token)
-            if num_match:
-                seasons.append(int(num_match.group(1)))
+            continue
+
+        # Single number, optionally prefixed with "s"/"season" (e.g. "s10" -> 10)
+        num_match = re.match(r"^(?:seasons?|s)?(\d{1,2})$", token)
+        if num_match:
+            seasons.append(int(num_match.group(1)))
     return sorted(list(set(seasons)))
 
 

--- a/server/app/modules/torrent_streams/utils/stream_file_resolver.py
+++ b/server/app/modules/torrent_streams/utils/stream_file_resolver.py
@@ -43,7 +43,15 @@ class StreamFileResolver:
         # Case 3: Search inside the files (Season pack & Multi-season pack)
         best_match: TorrentFileInfo | None = None
         for file in valid_files:
-            file_name_cleaned = clean_torrent_name(file.name)
+            # file.path (not file.name) is used here on purpose: file.name has
+            # its directory component stripped (see torrent_info.py), but many
+            # season packs are organized as per-season subfolders where the
+            # season number only appears in the folder (e.g. "S01/EP01.mkv"),
+            # never in the filename itself. parse_season_episode is already
+            # designed to receive a full path - it explicitly only strips the
+            # parent folder for the risky "lone digit as episode" fallback,
+            # while deliberately keeping it for season detection.
+            file_name_cleaned = clean_torrent_name(file.path)
             file_seasons, file_episodes = parse_season_episode(file_name_cleaned)
 
             if not file_episodes or series.episode not in file_episodes:

--- a/server/tests/test_ncore_indexer.py
+++ b/server/tests/test_ncore_indexer.py
@@ -1,0 +1,257 @@
+"""
+Tesztek a NcoreIndexerDefinition attribútum-felismeréséhez.
+
+A régi implementáció a felbontást és a nyelvet kizárólag az nCore durva
+kategória-tagjéből (pl. "hdser_hun") határozta meg, ami két konkrét hibát
+okozott:
+
+1. Minden "hd*" kategóriájú találat 720p-nek látszott, még akkor is, ha a
+   release név egyértelműen 1080p-t vagy 2160p-t jelzett.
+2. A többévados csomagok (pl. "S01-S04") évad-listája a series_parser egy
+   külön hibája miatt teljesen elveszett (lásd test_torrent_parsers.py).
+
+Ez a teszt-modul a nCore keresési API valós mintaválaszán (lásd
+NCORE_SAMPLE_RESPONSE) és számos további szélsőséges eseten keresztül
+ellenőrzi mindkét javítást.
+"""
+
+import pytest
+
+from app.modules.indexer_definitions.integrations.ncore import NcoreIndexerDefinition
+from app.modules.torrent_streams.utils.series_parser import parse_season_episode
+
+# A feladatban megadott, valódi nCore API válasz (torrents.php?jsons=True) 12
+# találata. Minden bejegyzésnél feltüntetjük a kategóriát és a release nevet,
+# amik alapján az indexernek helyesen kell felismernie a felbontást, a
+# nyelvet és (a series_parser oldalán) az évad-listát is.
+NCORE_SAMPLE_RESPONSE = {
+    "results": [
+        {
+            "torrent_id": "3658580",
+            "category": "hdser_hun",
+            "release_name": "Miraculous.Tales.Of.Ladybug.and.Cat.Noir.S05.720p.DSNP.WEB-DL.DDP5.1.H.264.HUN.FRE.ENG-VARYG",
+        },
+        {
+            "torrent_id": "3375915",
+            "category": "xvidser_hun",
+            "release_name": "Miraculous - Katicabogár és Fekete Macska kalandjai S04",
+        },
+        {
+            "torrent_id": "3433977",
+            "category": "xvidser_hun",
+            "release_name": "Miraculous - Katicabogár és Fekete Macska kalandjai S01",
+        },
+        {
+            "torrent_id": "3375876",
+            "category": "xvidser_hun",
+            "release_name": "Miraculous - Katicabogár és Fekete Macska kalandjai S02",
+        },
+        {
+            "torrent_id": "3434004",
+            "category": "xvidser_hun",
+            "release_name": "Miraculous - Katicabogár és Fekete Macska kalandjai S03",
+        },
+        {
+            "torrent_id": "3329105",
+            "category": "hdser_hun",
+            "release_name": "Miraculous - Katicabogár és Fekete Macska kalandjai S01-S04 720p",
+        },
+        {
+            "torrent_id": "3658581",
+            "category": "hdser_hun",
+            "release_name": "Miraculous.Tales.Of.Ladybug.and.Cat.Noir.S05.1080p.DSNP.WEB-DL.DDP5.1.H.264.HUN.FRE.ENG-VARYG",
+        },
+        {
+            "torrent_id": "3329383",
+            "category": "hdser_hun",
+            "release_name": "Miraculous - Katicabogár és Fekete Macska kalandjai S01-S04 1080p",
+        },
+        {
+            "torrent_id": "4141749",
+            "category": "hdser",
+            "release_name": "Miraculous.Tales.Of.Ladybug.and.Cat.Noir.S06.Part1.720p.DSNP.WEB-DL.DDP5.1.H.264-FULCRUM",
+        },
+        {
+            "torrent_id": "4141751",
+            "category": "hdser",
+            "release_name": "Miraculous.Tales.Of.Ladybug.and.Cat.Noir.S06.Part1.1080p.DSNP.WEB-DL.DDP5.1.H.264-FULCRUM",
+        },
+        {
+            "torrent_id": "3080646",
+            "category": "hdser",
+            "release_name": "Miraculous.World.New.York.United.Heroez.2020.1080p.HULU.WEB-DL.DDP5.1.H.264-LAZY",
+        },
+        {
+            "torrent_id": "3080574",
+            "category": "xvidser",
+            "release_name": "Miraculous.World.New.York.United.Heroez.2020.HULU.WEB-DL.DDP5.1.H.264-LAZY",
+        },
+    ]
+}
+
+# torrent_id -> (elvárt felbontás, elvárt nyelvek halmaza, elvárt évadok)
+EXPECTED = {
+    # Explicit "720p" a névben -> onnan kell jönnie, nem a kategóriából.
+    "3658580": ("720p", {"hun", "eng"}, [5]),
+    # Nincs felbontás a névben -> kategória fallback (xvidser -> 480p).
+    "3375915": ("480p", {"hun"}, [4]),
+    "3433977": ("480p", {"hun"}, [1]),
+    "3375876": ("480p", {"hun"}, [2]),
+    "3434004": ("480p", {"hun"}, [3]),
+    # Többévados ("S01-S04") csomag, explicit "720p" a névben.
+    "3329105": ("720p", {"hun"}, [1, 2, 3, 4]),
+    # A régi hiba itt adott volna hibás eredményt: a kategória "hdser_hun"
+    # minden HD találatot 720p-nek jelölt, holott ez expliciten 1080p.
+    "3658581": ("1080p", {"hun", "eng"}, [5]),
+    # Ugyanez többévados csomagra: kategória alapján 720p lenne, valójában 1080p.
+    "3329383": ("1080p", {"hun"}, [1, 2, 3, 4]),
+    # Nincs "_hun" a kategóriában és a névben sincs nyelvjelölés -> ENG fallback.
+    "4141749": ("720p", {"eng"}, [6]),
+    "4141751": ("1080p", {"eng"}, [6]),
+    "3080646": ("1080p", {"eng"}, None),
+    "3080574": ("480p", {"eng"}, None),
+}
+
+
+@pytest.fixture(scope="module")
+def indexer() -> NcoreIndexerDefinition:
+    return NcoreIndexerDefinition()
+
+
+@pytest.mark.parametrize(
+    "torrent", NCORE_SAMPLE_RESPONSE["results"], ids=lambda t: t["torrent_id"]
+)
+def test_ncore_resolution_and_language_from_sample_response(indexer, torrent):
+    torrent_id = torrent["torrent_id"]
+    expected_resolution, expected_languages, _ = EXPECTED[torrent_id]
+
+    attribute_ids = indexer._resolve_attribute_ids(
+        torrent["category"], torrent["release_name"]
+    )
+
+    resolutions = {"2160p", "1080p", "720p", "576p", "540p", "480p"} & set(
+        attribute_ids
+    )
+    languages = {"hun", "eng"} & set(attribute_ids)
+
+    assert resolutions == {expected_resolution}, (
+        f"{torrent_id}: várt felbontás {expected_resolution!r}, "
+        f"kapott attribute_ids={attribute_ids!r}"
+    )
+    assert languages == expected_languages, (
+        f"{torrent_id}: várt nyelv(ek) {expected_languages!r}, "
+        f"kapott attribute_ids={attribute_ids!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "torrent", NCORE_SAMPLE_RESPONSE["results"], ids=lambda t: t["torrent_id"]
+)
+def test_ncore_sample_season_parsing(torrent):
+    torrent_id = torrent["torrent_id"]
+    _, _, expected_seasons = EXPECTED[torrent_id]
+
+    seasons, _episodes = parse_season_episode(torrent["release_name"])
+
+    assert seasons == expected_seasons, (
+        f"{torrent_id}: várt évadok {expected_seasons!r}, kapott {seasons!r} "
+        f"({torrent['release_name']!r})"
+    )
+
+
+def test_ncore_multi_season_pack_regresses_to_720p_without_explicit_resolution(
+    indexer,
+):
+    """
+    A "hdser_hun" kategória önmagában nem különbözteti meg a 720p/1080p/2160p
+    HD felbontásokat - ha a release névből sem derül ki a felbontás, a
+    kategória-fallback (720p) az egyetlen elérhető jelzés.
+    """
+    attribute_ids = indexer._resolve_attribute_ids(
+        "hdser_hun", "Miraculous - Katicabogár és Fekete Macska kalandjai S04"
+    )
+    assert "720p" in attribute_ids
+    assert "1080p" not in attribute_ids
+    assert "2160p" not in attribute_ids
+
+
+class TestResolutionDetectionRegressions:
+    """
+    Célzott regressziós tesztek arra a hibára, hogy a régi implementáció
+    minden "hd*" kategóriájú találatot 720p-nek jelölt, függetlenül attól,
+    hogy a release név 1080p-t vagy 2160p-t tartalmazott.
+    """
+
+    @pytest.mark.parametrize(
+        ("category", "release_name", "expected_resolution"),
+        [
+            ("hd", "Movie.2024.720p.WEB-DL.x264-GROUP", "720p"),
+            ("hd", "Movie.2024.1080p.WEB-DL.x264-GROUP", "1080p"),
+            ("hd", "Movie.2024.2160p.UHD.WEB-DL.x265-GROUP", "2160p"),
+            ("hd_hun", "Movie.2024.1080p.BluRay.x264.HUN-GROUP", "1080p"),
+            ("hdser", "Show.S01E01.2160p.NF.WEB-DL.DDP5.1.x265-GROUP", "2160p"),
+            # Nincs felbontás a névben -> kategória fallback.
+            ("hd", "Movie 2024 HUN", "720p"),
+            ("xvid", "Movie 2024 HUN", "480p"),
+        ],
+    )
+    def test_resolution_matches_release_name_over_category(
+        self, indexer, category, release_name, expected_resolution
+    ):
+        attribute_ids = indexer._resolve_attribute_ids(category, release_name)
+        resolutions = {"2160p", "1080p", "720p", "576p", "480p"} & set(attribute_ids)
+        assert resolutions == {expected_resolution}
+
+
+class TestMultiSeasonRangeRegressions:
+    """
+    Célzott regressziós tesztek a _parse_season_list hibájára, ami miatt
+    minden olyan évad-tartomány, ahol a felső határ is "S" előtaggal
+    szerepelt (pl. "S01-S04", "S01 to S28"), teljesen None-t adott vissza.
+    """
+
+    @pytest.mark.parametrize(
+        ("release_name", "expected_seasons"),
+        [
+            # Az eredetileg megadott hibás eset.
+            ("Show.Name.S01-S04.COMPLETE.720p.WEB-DL.x264-GROUP", [1, 2, 3, 4]),
+            # Dupla számjegyű határok.
+            ("Show.Name.S01-S12.COMPLETE.1080p.WEB-DL.x264-GROUP", list(range(1, 13))),
+            # Szóközzel körülvett kötőjel.
+            ("Show Name S01 - S13 Complete", list(range(1, 14))),
+            # "to" elválasztó mindkét oldalon "S" előtaggal.
+            ("Show Name Complete Seasons S01 to S28", list(range(1, 29))),
+            # Csak a felső határ visel "S" előtagot.
+            ("Show Name Season 1-10 Complete", list(range(1, 11))),
+            # Csak az alsó határ visel "S" előtagot (szélsőséges eset).
+            ("Show Name S1-10 Complete", list(range(1, 11))),
+            # "season" szó mindkét oldalon.
+            ("Show Name Season1-Season4 Complete", [1, 2, 3, 4]),
+            # Egyetlen évad (nem tartomány) - nem szabad regressziót okoznia.
+            ("Show.Name.S05.Complete.720p-GROUP", [5]),
+            # Vessző-elválasztott lista, nem tartomány.
+            ("Show Name Seasons 1, 2, 3 Complete", [1, 2, 3]),
+        ],
+    )
+    def test_season_range_parsing(self, release_name, expected_seasons):
+        seasons, _episodes = parse_season_episode(release_name)
+        assert seasons == expected_seasons
+
+    def test_descending_range_is_not_silently_swapped(self):
+        # Fordított sorrendű "tartomány" (S04-S01) nem valódi tartomány;
+        # a meglévő _expand_range logika ilyenkor csak a kezdőértéket adja
+        # vissza, ahelyett hogy hibásan felcserélné a határokat.
+        seasons, _episodes = parse_season_episode(
+            "Show.Name.S04-S01.COMPLETE.720p-GROUP"
+        )
+        assert seasons == [4]
+
+    def test_unreasonably_large_range_is_capped(self):
+        # Az _expand_range 100-as felső korlátja miatt egy nyilvánvalóan
+        # hibás/túl nagy tartomány nem generálhat száznál több elemet.
+        seasons, _episodes = parse_season_episode(
+            "Show.Name.S01-S99.COMPLETE.720p-GROUP"
+        )
+        assert seasons is not None
+        assert len(seasons) <= 101
+        assert seasons[0] == 1

--- a/server/tests/test_stream_file_resolver.py
+++ b/server/tests/test_stream_file_resolver.py
@@ -105,6 +105,58 @@ def test_resolve_series_multi_season_pack():
     assert result.path == "S02/The.Show.S02E04.mkv"
 
 
+def test_resolve_series_season_pack_with_season_only_in_folder_name():
+    """
+    Regresszió: néhány csomagban (pl. nCore-on gyakori "[Anime-BD] ... EPxx"
+    elnevezésű release-eknél) az évadszám KIZÁRÓLAG a szülőmappa nevében
+    szerepel (pl. "S01/"), a fájlnév önmagában csak az epizódszámot
+    tartalmazza ("... EP01 ....mkv"), évad-jelölés nélkül.
+
+    Ez korábban azért bukott el, mert a resolver a fájl NEVÉT (a mappa
+    nélkül) parsolta, holott a mappa neve hordozta az egyetlen évad-jelzést.
+    """
+    torrent_info = TorrentInfo(
+        info_hash="hash",
+        name="Miraculous - Katicabogár és Fekete Macska kalandjai S01-S04 1080p",
+        size=1000,
+        piece_size=10,
+        files=[
+            create_file(
+                "S01/[Anime-BD] Miraculous - Tales of Ladybug and Cat Noir EP01 (Netflix WEB-DL 1920x1080 x264 Multi-Audio).mkv",
+                1_100_000_000,
+            ),
+            create_file(
+                "S01/[Anime-BD] Miraculous - Tales of Ladybug and Cat Noir EP02 (Netflix WEB-DL 1920x1080 x264 Multi-Audio).mkv",
+                1_200_000_000,
+            ),
+            create_file(
+                "S02/[Anime-BD] Miraculous - Tales of Ladybug and Cat Noir 2 EP01 (Netflix WEB-DL 1920x1080 x264 Dual-Audio).mkv",
+                850_000_000,
+            ),
+        ],
+    )
+
+    result_s1e1 = StreamFileResolver.resolve_file(
+        torrent_info, SeriesInfo(season=1, episode=1)
+    )
+    assert result_s1e1 is not None
+    assert "EP01" in result_s1e1.path
+    assert result_s1e1.path.startswith("S01/")
+
+    result_s2e1 = StreamFileResolver.resolve_file(
+        torrent_info, SeriesInfo(season=2, episode=1)
+    )
+    assert result_s2e1 is not None
+    assert result_s2e1.path.startswith("S02/")
+
+    # Season that doesn't exist in the pack at all -> no match, not a
+    # false-positive from an unrelated file.
+    result_missing = StreamFileResolver.resolve_file(
+        torrent_info, SeriesInfo(season=9, episode=1)
+    )
+    assert result_missing is None
+
+
 def test_resolve_series_complete_pack_without_season_in_torrent_name():
     torrent_info = TorrentInfo(
         info_hash="hash",

--- a/server/tests/test_torrent_parsers.ambr
+++ b/server/tests/test_torrent_parsers.ambr
@@ -1,0 +1,6584 @@
+# serializer version: 1
+# name: test_torrent_parser_snapshots[ Tom.Clancys.Jack.Ryan.S02.COMPLETE.720p.AMZN.WEBRip.x264-GalaxyTV[TGx] ]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': ' Tom.Clancys.Jack.Ryan.S02.COMPLETE.720p.AMZN.WEBRip.x264-GalaxyTV[TGx] ',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[#Yaaram (2019) Hindi 720p DC WEBRip \u2b501.5 GB\u2b50 (DD- 2.0) HC ESub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'ac3',
+      'directors-cut',
+      'sdr',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': '#Yaaram (2019) Hindi 720p DC WEBRip ⭐1.5 GB⭐ (DD- 2.0) HC ESub x264 - Shadow (BonsaiHD)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[1917 (2019) [BluRay Rip 1080p ITA-ENG AC3 SUBS] [[email protected]]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'ac3',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': '1917 (2019) [BluRay Rip 1080p ITA-ENG AC3 SUBS] [[email protected]]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[1983 - Season 1 - Polish - 1080p AAC5.1 - NF WEB-DL - X264-Rapta]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': '1983 - Season 1 - Polish - 1080p AAC5.1 - NF WEB-DL - X264-Rapta',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[2001.A.Space.Odyssey.1968.iNTERNAL.1080p.BluRay.x264-MANNEKEPiS]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': '2001.A.Space.Odyssey.1968.iNTERNAL.1080p.BluRay.x264-MANNEKEPiS',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[2047 - Sights of Death (2014) 720p BrRip x264 - YIFY]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': '2047 - Sights of Death (2014) 720p BrRip x264 - YIFY',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[22 Jump Street (2014) 720p BrRip x264 - YIFY]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      22,
+    ]),
+    'filename': '22 Jump Street (2014) 720p BrRip x264 - YIFY',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[24.Hours.In.A.And.E.S21E02.1080p.HEVC.x265-MeGusta[eztv]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': '24.Hours.In.A.And.E.S21E02.1080p.HEVC.x265-MeGusta[eztv]',
+    'seasons': list([
+      21,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[2nd.Chance.Charlie.S01E02.HDTV.x264-FiHTV[TGx]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': '2nd.Chance.Charlie.S01E02.HDTV.x264-FiHTV[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[2nd.Chance.Charlie.S01E05.720p.HDTV.x264-FiHTV[eztv]]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      5,
+    ]),
+    'filename': '2nd.Chance.Charlie.S01E05.720p.HDTV.x264-FiHTV[eztv]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[37\xb02 le matin - Betty Blue (1986) Director's Cut.720p.H264.ita.fre.sub.Eng-MIRCrew]
+  dict({
+    'attributes': list([
+      '720p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      37,
+    ]),
+    'filename': "37°2 le matin - Betty Blue (1986) Director's Cut.720p.H264.ita.fre.sub.Eng-MIRCrew",
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[A Walk in the Woods (2015)Mp-4-X264-Dvd-Rip-480p-AAC-DSD]
+  dict({
+    'attributes': list([
+      '480p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'A Walk in the Woods (2015)Mp-4-X264-Dvd-Rip-480p-AAC-DSD',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[A.P.Bio.S03.1080p.PCOK.WEB-DL.DDP5.0.x264-NTb]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      0,
+    ]),
+    'filename': 'A.P.Bio.S03.1080p.PCOK.WEB-DL.DDP5.0.x264-NTb',
+    'seasons': list([
+      3,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[A.Touch.Of.Cloth.S03E01-E02.720p.WEB.h264-FaiLED[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+      2,
+    ]),
+    'filename': 'A.Touch.Of.Cloth.S03E01-E02.720p.WEB.h264-FaiLED[TGx]',
+    'seasons': list([
+      3,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[A.Whisker.Away.2020.JAPANESE.1080p.NF.WEBRip.DDP5.1.x264-NTG[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'A.Whisker.Away.2020.JAPANESE.1080p.NF.WEBRip.DDP5.1.x264-NTG[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[A3! Season Spring & Summer - 11 (360p)-HorribleSubs[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      11,
+    ]),
+    'filename': 'A3! Season Spring & Summer - 11 (360p)-HorribleSubs[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Accepted.2006.720p.HDDVD.DD5.1.x264-EbP]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Accepted.2006.720p.HDDVD.DD5.1.x264-EbP',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Accused.Guilty.or.Innocent.S01E07.Murdered.His.Mother.or.Falsely.Accused.Pt2.HDTV.x264-CRiMSON[TGx]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      7,
+    ]),
+    'filename': 'Accused.Guilty.or.Innocent.S01E07.Murdered.His.Mother.or.Falsely.Accused.Pt2.HDTV.x264-CRiMSON[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Adu (2020) 720p NF WEB-DL Dual Audio [English + spanish] \u2b50950 MB\u2b50  DD- 5.1 x265 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x265',
+    ]),
+    'episodes': list([
+      950,
+      50,
+    ]),
+    'filename': 'Adu (2020) 720p NF WEB-DL Dual Audio [English + spanish] ⭐950 MB⭐  DD- 5.1 x265 - Shadow (BonsaiHD)',
+    'seasons': list([
+      9,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Ahiru no Sora - 36 (480p)-HorribleSubs[TGx]]
+  dict({
+    'attributes': list([
+      '480p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      36,
+    ]),
+    'filename': 'Ahiru no Sora - 36 (480p)-HorribleSubs[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Akira (2016) - UpScaled - 720p - DesiSCR-Rip - Hindi - x264 - AC3 - 5.1 - Mafiaking - M2Tv]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Akira (2016) - UpScaled - 720p - DesiSCR-Rip - Hindi - x264 - AC3 - 5.1 - Mafiaking - M2Tv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Amar (2017) HDRip 720p Hindi + Spanish 800MB[MB].]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Amar (2017) HDRip 720p Hindi + Spanish 800MB[MB].',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[American Dad! S01 - S13 Complete]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'American Dad! S01 - S13 Complete',
+    'seasons': list([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[American.Masters.S33E15.Toni.Morrison.The.Pieces.I.Am.720p.WEB.h264-LiGATE[eztv]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      15,
+    ]),
+    'filename': 'American.Masters.S33E15.Toni.Morrison.The.Pieces.I.Am.720p.WEB.h264-LiGATE[eztv]',
+    'seasons': list([
+      33,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[American.Monster.S05E06.My.Body.720p.ID.WEB-DL.AAC2.0.x264-BOOP[eztv]]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'American.Monster.S05E06.My.Body.720p.ID.WEB-DL.AAC2.0.x264-BOOP[eztv]',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[And.We.Go.Green.2019.720p.HULU.WEBRip.800MB.x264-GalaxyRG]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'And.We.Go.Green.2019.720p.HULU.WEBRip.800MB.x264-GalaxyRG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Animals.S01.1080p.HBO.WEBRip.DD5.1.H.264-monkee]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Animals.S01.1080p.HBO.WEBRip.DD5.1.H.264-monkee',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Annabelle.2014.1080p.PROPER.HC.WEBRip.x264.AAC.2.0-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Annabelle.2014.1080p.PROPER.HC.WEBRip.x264.AAC.2.0-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Annabelle.2014.HC.HDRip.XViD.AC3-juggs[ETRG]]
+  dict({
+    'attributes': list([
+      'ac3',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Annabelle.2014.HC.HDRip.XViD.AC3-juggs[ETRG]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Ant-Man.2015.3D.1080p.BRRip.Half-SBS.x264.AAC-m2g]
+  dict({
+    'attributes': list([
+      '1080p',
+      '3d',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Ant-Man.2015.3D.1080p.BRRip.Half-SBS.x264.AAC-m2g',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Archer.S02.1080p.BluRay.DTSMA.AVC.Remux]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'remux',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Archer.S02.1080p.BluRay.DTSMA.AVC.Remux',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Are You Being Served (1972) Season 1-10 S01-S10 + Extras (576p AMZN WEB-DL x265 HEVC 10bit EAC3 2.0 MONOLITH) [QxR]]
+  dict({
+    'attributes': list([
+      '2.0',
+      '576p',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Are You Being Served (1972) Season 1-10 S01-S10 + Extras (576p AMZN WEB-DL x265 HEVC 10bit EAC3 2.0 MONOLITH) [QxR]',
+    'seasons': list([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Athlete.A.2020.1080p.WEB.H264-HUZZAH[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Athlete.A.2020.1080p.WEB.H264-HUZZAH[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Attack.on.Titan.S01.S02.S03.1080p.Blu-Ray.Remux.Dual-Audio.TrueHD]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'remux',
+      'sdr',
+      'theatrical',
+      'truehd',
+    ]),
+    'episodes': None,
+    'filename': 'Attack.on.Titan.S01.S02.S03.1080p.Blu-Ray.Remux.Dual-Audio.TrueHD',
+    'seasons': list([
+      1,
+      2,
+      3,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Avatar The Last Airbender - The Complete Series 1080p [HEVC AAC] - SEPH1]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Avatar The Last Airbender - The Complete Series 1080p [HEVC AAC] - SEPH1',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[BBC.Billy.and.Us.1080p.HDTV.x265.AAC.MVGroup.org.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'BBC.Billy.and.Us.1080p.HDTV.x265.AAC.MVGroup.org.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[BBC.When.Pop.Went.Epic.1080p.HDTV.x265.AAC.MVGroup.org.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'BBC.When.Pop.Went.Epic.1080p.HDTV.x265.AAC.MVGroup.org.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Babies.S02.COMPLETE.720p.NF.WEBRip.x264-GalaxyTV]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Babies.S02.COMPLETE.720p.NF.WEBRip.x264-GalaxyTV',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Babyteeth (2019) [1080p]  [WebRip] [YTS]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+    ]),
+    'episodes': None,
+    'filename': 'Babyteeth (2019) [1080p]  [WebRip] [YTS]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Bee.and.Puppycat.S01.1080p.VRV.WEB-DL.x264-Bernd_Lauert]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Bee.and.Puppycat.S01.1080p.VRV.WEB-DL.x264-Bernd_Lauert',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Ben Hur 2016 TELESYNC x264 AC3 MAXPRO]
+  dict({
+    'attributes': list([
+      'ac3',
+      'cam',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Ben Hur 2016 TELESYNC x264 AC3 MAXPRO',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Big.Brother.AU.S12E06.720p.WEBRip.x264-Nemo]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'Big.Brother.AU.S12E06.720p.WEBRip.x264-Nemo',
+    'seasons': list([
+      12,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Black Clover S01 USBD REMUX]
+  dict({
+    'attributes': list([
+      'remux',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Black Clover S01 USBD REMUX',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Black Hollywood: 'They've Gotta Have Us' S01 complete (BBC, 2018) (1280x720p HD, 50fps, soft Eng subs)]
+  dict({
+    'attributes': list([
+      '720p',
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': "Black Hollywood: 'They've Gotta Have Us' S01 complete (BBC, 2018) (1280x720p HD, 50fps, soft Eng subs)",
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Black Lagoon (Seasons 1-2 + OVAs) (BD 1080p)(HEVC x265 10bit)(Dual-Audio)(Eng-Subs)-Judas[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Black Lagoon (Seasons 1-2 + OVAs) (BD 1080p)(HEVC x265 10bit)(Dual-Audio)(Eng-Subs)-Judas[TGx]',
+    'seasons': list([
+      1,
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Black.Rain.1989.MULTi.1080p.BluRay.REMUX.MPEG-2.DTS-ES.6.1-LTS.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'dts',
+      'remux',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'Black.Rain.1989.MULTi.1080p.BluRay.REMUX.MPEG-2.DTS-ES.6.1-LTS.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Blind.2017.NORDiC.720p.BluRay.x264.DTS5.1-TWA]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Blind.2017.NORDiC.720p.BluRay.x264.DTS5.1-TWA',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Blindspot.S05E06.Fire.and.Brimstone.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'Blindspot.S05E06.Fire.and.Brimstone.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb[TGx]',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Boi.2016.1080p.BluRay.x264-BARGAiN[EtHD]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Boi.2016.1080p.BluRay.x264-BARGAiN[EtHD]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Boku.Unmei.no.Hito.desu.Ep07.Chi_Jap.HDTVrip.1280X720-ZhuixinFan.mp4]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      7,
+    ]),
+    'filename': 'Boku.Unmei.no.Hito.desu.Ep07.Chi_Jap.HDTVrip.1280X720-ZhuixinFan.mp4',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Bolt.2008.MULTI.BluRay.3D.1080p.AVC.DTS-HD.MA.DD.EX.5.1-SnOoP-UPR.iso]
+  dict({
+    'attributes': list([
+      '1080p',
+      '3d',
+      '5.1',
+      'ac3',
+      'bluray',
+      'dts-hd-ma',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Bolt.2008.MULTI.BluRay.3D.1080p.AVC.DTS-HD.MA.DD.EX.5.1-SnOoP-UPR.iso',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Borgen S1E9 - Divide and Rule ('Del og hersk').mp4]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      9,
+    ]),
+    'filename': "Borgen S1E9 - Divide and Rule ('Del og hersk').mp4",
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Borgen-Season 1-[2010].x264.DVDrip]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Borgen-Season 1-[2010].x264.DVDrip',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Brave.2012.R5.DVDRip.XViD.LiNE-UNiQUE]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Brave.2012.R5.DVDRip.XViD.LiNE-UNiQUE',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Bumbibjornarna.COMPLETE.S02.SWEDiSH.DVDRip.XviD-Rezar1337]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Bumbibjornarna.COMPLETE.S02.SWEDiSH.DVDRip.XviD-Rezar1337',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Casino (1995) (1080p BluRay x265 HEVC 10bit HDR AAC 7.1 afm72) [QxR]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '7.1',
+      'aac',
+      'bluray',
+      'hdr10',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Casino (1995) (1080p BluRay x265 HEVC 10bit HDR AAC 7.1 afm72) [QxR]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Casino.1995.MULTi.REMUX.2160p.UHD.Blu-ray.HDR.HEVC.DTS-X7.1-DENDA.mkv]
+  dict({
+    'attributes': list([
+      '2160p',
+      '7.1',
+      'bluray',
+      'hdr10',
+      'remux',
+      'theatrical',
+      'uhd',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Casino.1995.MULTi.REMUX.2160p.UHD.Blu-ray.HDR.HEVC.DTS-X7.1-DENDA.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Chaman Bahar (2020) Hindi 720p NF WEBRip \u2b50800 MB\u2b50 DD- 5.1 ESub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      800,
+      0,
+    ]),
+    'filename': 'Chaman Bahar (2020) Hindi 720p NF WEBRip ⭐800 MB⭐ DD- 5.1 ESub x264 - Shadow (BonsaiHD)',
+    'seasons': list([
+      8,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Clerks II (2006) (1080p BDRip x265 10bit TrueHD 5.1 - xtrem3x)[TAoE].mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'bdrip',
+      'sdr',
+      'theatrical',
+      'truehd',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Clerks II (2006) (1080p BDRip x265 10bit TrueHD 5.1 - xtrem3x)[TAoE].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Community.s02e20.rus.eng.720p.Kybik.v.Kybe]
+  dict({
+    'attributes': list([
+      '720p',
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      20,
+    ]),
+    'filename': 'Community.s02e20.rus.eng.720p.Kybik.v.Kybe',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Coronation Street 2020 1080p (Deep61)[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Coronation Street 2020 1080p (Deep61)[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Cousins.2019.PORTUGUESE.1080p.BluRay.H264.AAC-VXT]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Cousins.2019.PORTUGUESE.1080p.BluRay.H264.AAC-VXT',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Coyote.Peterson-Brave.the.Wild.S01E00.Coyotes.Journal.Coyote.And.His.Faithful.Crew.iNTERNAL.WEB.x264-ROBOTS[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      0,
+    ]),
+    'filename': 'Coyote.Peterson-Brave.the.Wild.S01E00.Coyotes.Journal.Coyote.And.His.Faithful.Crew.iNTERNAL.WEB.x264-ROBOTS[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Crazy4TV.com - Dark Matter Season 1 S01 720p BluRay x265 HEVC Crazy4ad]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Crazy4TV.com - Dark Matter Season 1 S01 720p BluRay x265 HEVC Crazy4ad',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dag.Vreemde.Man.2016.1080p.BluRay.x264-BARGAiN[EtHD]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Dag.Vreemde.Man.2016.1080p.BluRay.x264-BARGAiN[EtHD]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Darkness Falls (2020) HDRip 720p [Hindi-Dub] Dual-Audio x264 - 1XCinema]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Darkness Falls (2020) HDRip 720p [Hindi-Dub] Dual-Audio x264 - 1XCinema',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Darlin (2019) ITA-ENG Bluray 1080p  - L@Z59 - iDN CreW.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Darlin (2019) ITA-ENG Bluray 1080p  - L@Z59 - iDN CreW.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dawn.Of.The.Planet.of.The.Apes.2014.1080p.WEB-DL.DD51.H264-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Dawn.Of.The.Planet.of.The.Apes.2014.1080p.WEB-DL.DD51.H264-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dawn.of.the.Planet.of.the.Apes.2014.HDRip.XViD-EVO]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Dawn.of.the.Planet.of.the.Apes.2014.HDRip.XViD-EVO',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dead Heat on a Merry Go Round [1966 - USA] thriller]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Dead Heat on a Merry Go Round [1966 - USA] thriller',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Deadliest.Catch.S00E66.No.Safe.Passage.720p.AMZN.WEB-DL.DDP2.0.H.264-NTb[TGx]]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      66,
+    ]),
+    'filename': 'Deadliest.Catch.S00E66.No.Safe.Passage.720p.AMZN.WEB-DL.DDP2.0.H.264-NTb[TGx]',
+    'seasons': list([
+      0,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Design.at.Your.Door.S01E03.Major.Bonus.Room.WEB.h264-ROBOTS[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'Design.at.Your.Door.S01E03.Major.Bonus.Room.WEB.h264-ROBOTS[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Detective Byomkesh Bakshy 2015 Hindi 720p BluRay x264 DTS 5.1 MSubs - LOKiHD - Telly]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'bluray',
+      'dts',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Detective Byomkesh Bakshy 2015 Hindi 720p BluRay x264 DTS 5.1 MSubs - LOKiHD - Telly',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Diabolique (1996).720p.H264.ita.eng.Ac3-5.1.sub.ita.eng-MIRCrew]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Diabolique (1996).720p.H264.ita.eng.Ac3-5.1.sub.ita.eng-MIRCrew',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Digimon Adventure (2020) - S01E05-Judas[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      5,
+    ]),
+    'filename': 'Digimon Adventure (2020) - S01E05-Judas[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dil Chahta Hai 2001 Hindi 1080p BluRay x264 DTS-HDMA 5.1 - Hon3yHD]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'bluray',
+      'dts-hd-ma',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Dil Chahta Hai 2001 Hindi 1080p BluRay x264 DTS-HDMA 5.1 - Hon3yHD',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Diners.Drive-Ins.and.Dives.S31E12.Sicilian.and.Seafood.WEBRip.x264-LiGATE[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Diners.Drive-Ins.and.Dives.S31E12.Sicilian.and.Seafood.WEBRip.x264-LiGATE[TGx]',
+    'seasons': list([
+      31,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dinosaur 13 2014 WEBrip XviD AC3 MiLLENiUM]
+  dict({
+    'attributes': list([
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+    ]),
+    'episodes': list([
+      13,
+    ]),
+    'filename': 'Dinosaur 13 2014 WEBrip XviD AC3 MiLLENiUM',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Doctor.Who.2005.8x11.Dark.Water.720p.HDTV.x264-FoV[rartv]]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      11,
+    ]),
+    'filename': 'Doctor.Who.2005.8x11.Dark.Water.720p.HDTV.x264-FoV[rartv]',
+    'seasons': list([
+      8,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Doppia Pelle - Le Daim (2019) BluRay 1080p.H264 Ita Fre AC3 5.1 Sub Ita Eng MIRCrew]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Doppia Pelle - Le Daim (2019) BluRay 1080p.H264 Ita Fre AC3 5.1 Sub Ita Eng MIRCrew',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Downton Abbey 5x06 HDTV x264-FoV [eztv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'Downton Abbey 5x06 HDTV x264-FoV [eztv]',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dr.Phil.2019.04.19.720p.HDTV.x264-W4F[rartv]]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'Dr.Phil.2019.04.19.720p.HDTV.x264-W4F[rartv]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dracula.Untold.2014.TS.XViD.AC3.MrSeeN-SiMPLE]
+  dict({
+    'attributes': list([
+      'ac3',
+      'cam',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Dracula.Untold.2014.TS.XViD.AC3.MrSeeN-SiMPLE',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dragon Ball Super: Broly (2018) CAM-Rip English Subs x264 - KatmovieHD.Pw]
+  dict({
+    'attributes': list([
+      'cam',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Dragon Ball Super: Broly (2018) CAM-Rip English Subs x264 - KatmovieHD.Pw',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Dukhtar 2014 Urdu 1080p BluRay x264 DD 5.1 ESubs - LOKiHD - Telly]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Dukhtar 2014 Urdu 1080p BluRay x264 DD 5.1 ESubs - LOKiHD - Telly',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[EastEnders.2020.06.16.WEB.h264-WEBTUBE[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'EastEnders.2020.06.16.WEB.h264-WEBTUBE[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Easy Rider  (Drama 1969)  Peter Fonda  720p  BrRip]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Easy Rider  (Drama 1969)  Peter Fonda  720p  BrRip',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Eating.Up.Easter.2018.DOCU.HDTV.x264-W4F[TGx]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Eating.Up.Easter.2018.DOCU.HDTV.x264-W4F[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Eliza Graves (2014) Dual Audio WEB-DL 720p MKV x264]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Eliza Graves (2014) Dual Audio WEB-DL 720p MKV x264',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Ella Fitzgerald - Just One of Those Things MP4 + subs BigJ0554]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Ella Fitzgerald - Just One of Those Things MP4 + subs BigJ0554',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Empire.2015.S06E16.WEB.H264-iNSiDiOUS[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      16,
+    ]),
+    'filename': 'Empire.2015.S06E16.WEB.H264-iNSiDiOUS[TGx]',
+    'seasons': list([
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Escape.Room.Tournament.of.Champions.2021.PL.EXTENDED.1080p.BRRip.HE-AACv2.AV1.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'av1',
+      'extended',
+      'sdr',
+    ]),
+    'episodes': None,
+    'filename': 'Escape.Room.Tournament.of.Champions.2021.PL.EXTENDED.1080p.BRRip.HE-AACv2.AV1.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Eu.gosto.do.Homem-Aranha.....y.dai.1080p.AAC2.0.H264.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Eu.gosto.do.Homem-Aranha.....y.dai.1080p.AAC2.0.H264.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Eu.gosto.do.Homem-Aranha.e.dai.1080p.AAC2.0.H264.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Eu.gosto.do.Homem-Aranha.e.dai.1080p.AAC2.0.H264.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Extraterrestrial.2011.BluRay.1080i.DTS-HD.MA.5.1.AVC.REMUX-FraMeSToR.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'bluray',
+      'dts-hd-ma',
+      'remux',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Extraterrestrial.2011.BluRay.1080i.DTS-HD.MA.5.1.AVC.REMUX-FraMeSToR.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Face 2 Face (2019) Kannada HDRip - 720p - x264 - DD5.1 - 1.1GB - ESub - TamilMV]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'Face 2 Face (2019) Kannada HDRip - 720p - x264 - DD5.1 - 1.1GB - ESub - TamilMV',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Family.Guy.S17.Complete.Season.17.x264.720p]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Family.Guy.S17.Complete.Season.17.x264.720p',
+    'seasons': list([
+      17,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Fear.the.Walking.Dead.S05E09.Canale.4.ITA.ENG.1080p.Bluray.x264-MeM.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      9,
+    ]),
+    'filename': 'Fear.the.Walking.Dead.S05E09.Canale.4.ITA.ENG.1080p.Bluray.x264-MeM.mkv',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Five.1951.DVDRip.XViD.B&W.Eng.1Ch.Audio.ETRG]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Five.1951.DVDRip.XViD.B&W.Eng.1Ch.Audio.ETRG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Friends.S09E23E24.720p.BluRay.DD5.1.x264-NTb.mkv]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Friends.S09E23E24.720p.BluRay.DD5.1.x264-NTb.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Frontline.S38E20.Opioids.Inc.WEB.h264-LiGATE[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      20,
+    ]),
+    'filename': 'Frontline.S38E20.Opioids.Inc.WEB.h264-LiGATE[TGx]',
+    'seasons': list([
+      38,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Fruits Basket S2 (2019) - 11 (720p)-HorribleSubs[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      11,
+    ]),
+    'filename': 'Fruits Basket S2 (2019) - 11 (720p)-HorribleSubs[TGx]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Game of Thrones - 4x03 - Breaker of Chains]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'Game of Thrones - 4x03 - Breaker of Chains',
+    'seasons': list([
+      4,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Gangs.Of.London.S01E01.Episodio.01.ITA.ENG.1080p.AHDTVMux.x264-Morpheus.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Gangs.Of.London.S01E01.Episodio.01.ITA.ENG.1080p.AHDTVMux.x264-Morpheus.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Ghost.Stories.S01.DVDRip.OGG.x264-Exiled-Destiny]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Ghost.Stories.S01.DVDRip.OGG.x264-Exiled-Destiny',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Gotham.S01E05.Viper.WEB-DL.x264.AAC]
+  dict({
+    'attributes': list([
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      5,
+    ]),
+    'filename': 'Gotham.S01E05.Viper.WEB-DL.x264.AAC',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Gotham.S01E07.Penguins.Umbrella.WEB-DL.x264.AAC]
+  dict({
+    'attributes': list([
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      7,
+    ]),
+    'filename': 'Gotham.S01E07.Penguins.Umbrella.WEB-DL.x264.AAC',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Guardians Of The Galaxy 2014 R6 720p HDCAM x264-JYK]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Guardians Of The Galaxy 2014 R6 720p HDCAM x264-JYK',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Guardians of the Galaxy (2014) Dual Audio DVDRip AVI]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Guardians of the Galaxy (2014) Dual Audio DVDRip AVI',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Guardians of the Galaxy (CamRip / 2014)]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Guardians of the Galaxy (CamRip / 2014)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Haikyuu!! (Season 4 Part 1) (1080p)(HEVC x265 10bit)(Multi-Subs)-Judas[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Haikyuu!! (Season 4 Part 1) (1080p)(HEVC x265 10bit)(Multi-Subs)-Judas[TGx]',
+    'seasons': list([
+      4,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Harley.Quinn.S02E12.Lovers.Quarrel.1080p.DCU.WEB-DL.DDP5.1.H264-NTb[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Harley.Quinn.S02E12.Lovers.Quarrel.1080p.DCU.WEB-DL.DDP5.1.H264-NTb[TGx]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[HarmonQuest.S01.1080p.SESO.WEBRip.AAC2.0.x264-BTW]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'HarmonQuest.S01.1080p.SESO.WEBRip.AAC2.0.x264-BTW',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Heavy.Rescue.401.S02E10.480p.x264-mSD[TGx]]
+  dict({
+    'attributes': list([
+      '480p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      10,
+    ]),
+    'filename': 'Heavy.Rescue.401.S02E10.480p.x264-mSD[TGx]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Hercules (2014) 1080p BrRip H264 - YIFY]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Hercules (2014) 1080p BrRip H264 - YIFY',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Hercules (2014) WEBDL DVDRip XviD-MAX]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+      'web-dl',
+    ]),
+    'episodes': None,
+    'filename': 'Hercules (2014) WEBDL DVDRip XviD-MAX',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Hercules.2014.EXTENDED.1080p.WEB-DL.DD5.1.H264-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'extended',
+      'sdr',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Hercules.2014.EXTENDED.1080p.WEB-DL.DD5.1.H264-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Hercules.2014.Extended.Cut.HDRip.XViD-juggs[ETRG]]
+  dict({
+    'attributes': list([
+      'extended',
+      'sdr',
+    ]),
+    'episodes': None,
+    'filename': 'Hercules.2014.Extended.Cut.HDRip.XViD-juggs[ETRG]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Hero Mask S1 + S2 + Extras [npz][US BD REMUX, 1080p]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'remux',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Hero Mask S1 + S2 + Extras [npz][US BD REMUX, 1080p]',
+    'seasons': list([
+      1,
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Hive [2021 - Albania] drama]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Hive [2021 - Albania] drama',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Home Before Dark (2020) S01 (1080p ATVP Webrip x265 10bit EAC3 5.1 - ArcX)[TAoE]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Home Before Dark (2020) S01 (1080p ATVP Webrip x265 10bit EAC3 5.1 - ArcX)[TAoE]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Homeland.Season.1-4.Complete.720p.HDTV.X264-MRSK]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Homeland.Season.1-4.Complete.720p.HDTV.X264-MRSK',
+    'seasons': list([
+      1,
+      2,
+      3,
+      4,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[IMAX.Blue.Planet.1990.1080p.BluRay.REMUX.VC-1.TrueHD.5.1-EPSiLON.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'bluray',
+      'imax',
+      'remux',
+      'sdr',
+      'truehd',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'IMAX.Blue.Planet.1990.1080p.BluRay.REMUX.VC-1.TrueHD.5.1-EPSiLON.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[IP Man And Four Kings 2019 HDRip 1080p x264 AAC Mandarin HC CHS-ENG SUBS Mp4Ba]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'IP Man And Four Kings 2019 HDRip 1080p x264 AAC Mandarin HC CHS-ENG SUBS Mp4Ba',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Ice.Age.Collision.Course.2016.READNFO.720p.HDRIP.X264.AC3.TiTAN]
+  dict({
+    'attributes': list([
+      '720p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Ice.Age.Collision.Course.2016.READNFO.720p.HDRIP.X264.AC3.TiTAN',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[If.Loving.You.Is.Wrong.S05E11.I.Need.A.Hero.480p.x264-mSD[eztv]]
+  dict({
+    'attributes': list([
+      '480p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      11,
+    ]),
+    'filename': 'If.Loving.You.Is.Wrong.S05E11.I.Need.A.Hero.480p.x264-mSD[eztv]',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Impractical.Jokers.The.Movie.2020.1080p.WEBRip.x264.AAC5.1]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Impractical.Jokers.The.Movie.2020.1080p.WEBRip.x264.AAC5.1',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[In.the.Dark.2019.S02E10.The.Last.Dance.720p.AMZN.WEB-DL.DDP5.1.H.264-NTb[TGx]]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      10,
+    ]),
+    'filename': 'In.the.Dark.2019.S02E10.The.Last.Dance.720p.AMZN.WEB-DL.DDP5.1.H.264-NTb[TGx]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Infection-What We Become (2015) ITA-DAN Ac3 5.1 BDRip 1080p H264 [ArMor]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'bdrip',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Infection-What We Become (2015) ITA-DAN Ac3 5.1 BDRip 1080p H264 [ArMor]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Insecure.S04.COMPLETE.720p.AMZN.WEBRip.x264-GalaxyTV]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Insecure.S04.COMPLETE.720p.AMZN.WEBRip.x264-GalaxyTV',
+    'seasons': list([
+      4,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Interstellar (2014) CAM ENG x264 AAC-CPG]
+  dict({
+    'attributes': list([
+      'aac',
+      'cam',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Interstellar (2014) CAM ENG x264 AAC-CPG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Into The Storm 2014 1080p BRRip x264 DTS-JYK]
+  dict({
+    'attributes': list([
+      '1080p',
+      'dts',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Into The Storm 2014 1080p BRRip x264 DTS-JYK',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Into.The.Storm.2014.1080p.WEB-DL.AAC2.0.H264-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Into.The.Storm.2014.1080p.WEB-DL.AAC2.0.H264-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Inventing.Tomorrow.2018.DOCU.HDTV.x264-W4F[TGx]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Inventing.Tomorrow.2018.DOCU.HDTV.x264-W4F[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Its.Always.Sunny.In.Philadelphia.S12.1080p.Amazon.WEB-DL.DD+2.0.H.264-CtrlHD]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Its.Always.Sunny.In.Philadelphia.S12.1080p.Amazon.WEB-DL.DD+2.0.H.264-CtrlHD',
+    'seasons': list([
+      12,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Jack.And.The.Cuckoo-Clock.Heart.2013.BRRip XViD]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Jack.And.The.Cuckoo-Clock.Heart.2013.BRRip XViD',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Jagga Jagravan Joga 2020.1080p.AMZN.WEB.DL.DD.2.0.AVC.Dus.IcTv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Jagga Jagravan Joga 2020.1080p.AMZN.WEB.DL.DD.2.0.AVC.Dus.IcTv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Jamies.Super.Food.S02E04.WEB.H264-DENTiST[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'Jamies.Super.Food.S02E04.WEB.H264-DENTiST[TGx]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Jasper.Mall.2020.1080p.BluRay.REMUX.AVC.DTS-HD.MA.5.1-FGT]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'bluray',
+      'dts-hd-ma',
+      'remux',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Jasper.Mall.2020.1080p.BluRay.REMUX.AVC.DTS-HD.MA.5.1-FGT',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Jay And Silent Bob Strike Back (2001) (1080p BDRip x265 10bit EAC3 5.1 - xtrem3x)[TAoE].mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'bdrip',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Jay And Silent Bob Strike Back (2001) (1080p BDRip x265 10bit EAC3 5.1 - xtrem3x)[TAoE].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Jimmy.Fallon.2020.06.16.Gwyneth.Paltrow.720p.WEB.h264-TRUMP[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'Jimmy.Fallon.2020.06.16.Gwyneth.Paltrow.720p.WEB.h264-TRUMP[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Jimmy.Not.Funny.2017.08.01.Jerry.Benner.720p.HDTV.x264-SORNY[eztv].mkv]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      8,
+    ]),
+    'filename': 'Jimmy.Not.Funny.2017.08.01.Jerry.Benner.720p.HDTV.x264-SORNY[eztv].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[John.Wick.Chapter.2.2017.720p.BluRay.DD-EX.x264-TayTO]
+  dict({
+    'attributes': list([
+      '720p',
+      'ac3',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'John.Wick.Chapter.2.2017.720p.BluRay.DD-EX.x264-TayTO',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Johnny.English.2003.1080p.BluRay.x264-[YTS.AG]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Johnny.English.2003.1080p.BluRay.x264-[YTS.AG]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Johnny.English.Reborn.2011.1080p.BRRip.x264  [MovieOW]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Johnny.English.Reborn.2011.1080p.BRRip.x264  [MovieOW]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Johnny.English.Strikes.Again.2018.1080p.BluRay.x264-[YTS.AM]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Johnny.English.Strikes.Again.2018.1080p.BluRay.x264-[YTS.AM]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Joker(2019) English HC 720p HDRip x264 [ Hindi - Eng Multi Subs] Shadow (HDWebmovies)]
+  dict({
+    'attributes': list([
+      '720p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Joker(2019) English HC 720p HDRip x264 [ Hindi - Eng Multi Subs] Shadow (HDWebmovies)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Just Mercy - Il diritto di opporsi (2019) AC3 5.1 ITA.ENG 1080p H265 sub NUita.eng Sp33dy94 MIRCrew]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Just Mercy - Il diritto di opporsi (2019) AC3 5.1 ITA.ENG 1080p H265 sub NUita.eng Sp33dy94 MIRCrew',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Justified - Season 1 to 6 - Mp4 x264 AC3 1080p]
+  dict({
+    'attributes': list([
+      '1080p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Justified - Season 1 to 6 - Mp4 x264 AC3 1080p',
+    'seasons': list([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kadakh (2020) Hindi 720p SonyLiv WEB-DL \u2b501.1 GB\u2b50 AAC DD- 2.0 ESub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'aac',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Kadakh (2020) Hindi 720p SonyLiv WEB-DL ⭐1.1 GB⭐ AAC DD- 2.0 ESub x264 - Shadow (BonsaiHD)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kadakh 2020 Hindi 1080p WEBRip x264 AC3 ESubs - LOKiHD - Telly]
+  dict({
+    'attributes': list([
+      '1080p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Kadakh 2020 Hindi 1080p WEBRip x264 AC3 ESubs - LOKiHD - Telly',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kaguya-sama wa Kokurasetai S2 - 11 (720p)-HorribleSubs[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Kaguya-sama wa Kokurasetai S2 - 11 (720p)-HorribleSubs[TGx]',
+    'seasons': list([
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kaguya-sama wa Kokurasetai! Tensai-tachi no Renai Zunousen 2 - 11 (720p)-Erai-raws[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'Kaguya-sama wa Kokurasetai! Tensai-tachi no Renai Zunousen 2 - 11 (720p)-Erai-raws[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kakushigoto - 12 END (720p)-Erai-raws[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Kakushigoto - 12 END (720p)-Erai-raws[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kami no Tou - 12 (720p)(Multiple Subtitle)-Erai-raws[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Kami no Tou - 12 (720p)(Multiple Subtitle)-Erai-raws[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kami no Tou - S01E12-Judas[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Kami no Tou - S01E12-Judas[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kasganj 2019 Hindi 1080p Zee5 WebDL AVC AAC 2.0 ESub - Telly.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Kasganj 2019 Hindi 1080p Zee5 WebDL AVC AAC 2.0 ESub - Telly.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kasganj 2019 WebRip 720p Hindi x264 AAC ESub - mkvCinemas [Telly].mkv]
+  dict({
+    'attributes': list([
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Kasganj 2019 WebRip 720p Hindi x264 AAC ESub - mkvCinemas [Telly].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kavacham (2018) Proper HDRip - x264 - [Tamil + Telugu + Hindi] - 750MB - ESub - TamilMV]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Kavacham (2018) Proper HDRip - x264 - [Tamil + Telugu + Hindi] - 750MB - ESub - TamilMV',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kavali (2020) 720p Hindi Dubbed WEBHD 450MB - MovCr]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Kavali (2020) 720p Hindi Dubbed WEBHD 450MB - MovCr',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Kitsutsuki Tanteidokoro - 10 (720p)(Multiple Subtitle)-Erai-raws[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      10,
+    ]),
+    'filename': 'Kitsutsuki Tanteidokoro - 10 (720p)(Multiple Subtitle)-Erai-raws[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[L.A. Story (1991) [4K AI upscale H265 AAC 5.1 stereo EN JP] - CalicoSkies]
+  dict({
+    'attributes': list([
+      '2160p',
+      '5.1',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'L.A. Story (1991) [4K AI upscale H265 AAC 5.1 stereo EN JP] - CalicoSkies',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[L.ultima corve (1973) ITA-ENG Ac3 2.0 BDRip 1080p H264 [ArMor]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'ac3',
+      'bdrip',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'L.ultima corve (1973) ITA-ENG Ac3 2.0 BDRip 1080p H264 [ArMor]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[La signora di Shanghai-The lady from Shanghai (1947) ITA-ENG Ac3 2.0 BDRip 1080p H264 [ArMor]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'ac3',
+      'bdrip',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'La signora di Shanghai-The lady from Shanghai (1947) ITA-ENG Ac3 2.0 BDRip 1080p H264 [ArMor]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Label.Me.2019.720p.AMZN.WEBRip.800MB.x264-GalaxyRG]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Label.Me.2019.720p.AMZN.WEBRip.800MB.x264-GalaxyRG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Lalbazaar S01 E01-10 WebRip 720p Hindi x264 AAC - mkvCinemas [Telly]]
+  dict({
+    'attributes': list([
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+    ]),
+    'filename': 'Lalbazaar S01 E01-10 WebRip 720p Hindi x264 AAC - mkvCinemas [Telly]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Let.It.Fall.Los.Angeles.1982-1992.2017.DOCU.iNTERNAL.HDTV.x264-W4F[rartv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Let.It.Fall.Los.Angeles.1982-1992.2017.DOCU.iNTERNAL.HDTV.x264-W4F[rartv]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Lets.Be.Cops.2014.BRRip.XViD-juggs[ETRG]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Lets.Be.Cops.2014.BRRip.XViD-juggs[ETRG]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Letterkenny.S05.720p.CRAV.WEB-DL.AAC2.0.H.264-BTW]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Letterkenny.S05.720p.CRAV.WEB-DL.AAC2.0.H.264-BTW',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Lollapalooza.2022.Cat.Dealers.1080p.WEB-DL.AAC2.0.x264.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Lollapalooza.2022.Cat.Dealers.1080p.WEB-DL.AAC2.0.x264.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Lost.Gold.of.World.War.II.S02E07.WEB.h264-TRUMP[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      7,
+    ]),
+    'filename': 'Lost.Gold.of.World.War.II.S02E07.WEB.h264-TRUMP[TGx]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Lucy 2014 Dual-Audio 720p WEBRip]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+    ]),
+    'episodes': None,
+    'filename': 'Lucy 2014 Dual-Audio 720p WEBRip',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Lucy 2014 Dual-Audio WEBRip 1400Mb]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-rip',
+    ]),
+    'episodes': None,
+    'filename': 'Lucy 2014 Dual-Audio WEBRip 1400Mb',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Lucy.2014.HC.HDRip.XViD-juggs[ETRG]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Lucy.2014.HC.HDRip.XViD-juggs[ETRG]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Lupin.III.The.First.2019.JAPANESE.1080p.BluRay.x265-VXT]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Lupin.III.The.First.2019.JAPANESE.1080p.BluRay.x265-VXT',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[M.S. Dhoni: The Untold Story (2016) BR-Rip - x264 - [Telugu + Tamil] - 450MB - ESub - TamilMV]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'M.S. Dhoni: The Untold Story (2016) BR-Rip - x264 - [Telugu + Tamil] - 450MB - ESub - TamilMV',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[M.S. Dhoni: The Untold Story (2016) BluRay - 720p - (DD5.1) [Telugu + Tamil + Hindi] - 1.6GB - ESub - TamilMV]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'bluray',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'M.S. Dhoni: The Untold Story (2016) BluRay - 720p - (DD5.1) [Telugu + Tamil + Hindi] - 1.6GB - ESub - TamilMV',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[MASH.S01E20.The.Army-Navy.Game.1080p.HULU.WEB-DL.AAC2.0.H.264-AJP69[eztv]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      20,
+    ]),
+    'filename': 'MASH.S01E20.The.Army-Navy.Game.1080p.HULU.WEB-DL.AAC2.0.H.264-AJP69[eztv]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Mae.West.Dirty.Blonde.2019.DOCU.720p.HDTV.800MB.x264-GalaxyRG]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Mae.West.Dirty.Blonde.2019.DOCU.720p.HDTV.800MB.x264-GalaxyRG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Magnum.P.I.2018.S03E04.720p.HDTV.x264-SYNCOPY]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'Magnum.P.I.2018.S03E04.720p.HDTV.x264-SYNCOPY',
+    'seasons': list([
+      3,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Main Teri Tu Mera 2016 Punjabi 720p WEBRip ESubs - LMH123]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+    ]),
+    'episodes': None,
+    'filename': 'Main Teri Tu Mera 2016 Punjabi 720p WEBRip ESubs - LMH123',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Malcolm.in.the.Middle.S01-S07.COMPLETE.READ.NFO.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland/Malcolm.in.the.Middle.S05.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland/Malcolm.in.the.Middle.S05E19.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland.mkv]
+  dict({
+    'attributes': list([
+      '5.1',
+      '576p',
+      'ac3',
+      'eng',
+      'hun',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      19,
+    ]),
+    'filename': 'Malcolm.in.the.Middle.S01-S07.COMPLETE.READ.NFO.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland/Malcolm.in.the.Middle.S05.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland/Malcolm.in.the.Middle.S05E19.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland.mkv',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Malcolm.in.the.Middle.S01-S07.COMPLETE.READ.NFO.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland/Malcolm.in.the.Middle.S06.1080p.HULU.WEB-DL.AAC2.0.H.264.HUN.ENG-pcroland/Malcolm.in.the.Middle.S06E08.1080p.HULU.WEB-DL.AAC2.0.H.264.HUN.ENG-pcroland.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'aac',
+      'ac3',
+      'eng',
+      'hun',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      8,
+    ]),
+    'filename': 'Malcolm.in.the.Middle.S01-S07.COMPLETE.READ.NFO.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland/Malcolm.in.the.Middle.S06.1080p.HULU.WEB-DL.AAC2.0.H.264.HUN.ENG-pcroland/Malcolm.in.the.Middle.S06E08.1080p.HULU.WEB-DL.AAC2.0.H.264.HUN.ENG-pcroland.mkv',
+    'seasons': list([
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Malcolm.in.the.Middle.S01-S07.COMPLETE.READ.NFO.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland]
+  dict({
+    'attributes': list([
+      '5.1',
+      '576p',
+      'ac3',
+      'eng',
+      'hun',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Malcolm.in.the.Middle.S01-S07.COMPLETE.READ.NFO.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland',
+    'seasons': list([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Marvel's.Agents.of.S.H.I.E.L.D.S02E01.Shadows.1080p.WEB-DL.DD5.1]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': "Marvel's.Agents.of.S.H.I.E.L.D.S02E01.Shadows.1080p.WEB-DL.DD5.1",
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Marvels Agents of S H I E L D S02E05 HDTV x264-KILLERS [eztv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      5,
+    ]),
+    'filename': 'Marvels Agents of S H I E L D S02E05 HDTV x264-KILLERS [eztv]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Marvels Agents of S.H.I.E.L.D. S02E06 HDTV x264-KILLERS[ettv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'Marvels Agents of S.H.I.E.L.D. S02E06 HDTV x264-KILLERS[ettv]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Marvels Iron Fist S02 Complete 720p WEB-DL x264 [4.3GB] [MP4] [Season 2]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'Marvels Iron Fist S02 Complete 720p WEB-DL x264 [4.3GB] [MP4] [Season 2]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Marvels.Agents.of.S.H.I.E.L.D.S07E03.Comunisti.alieni.dal.futuro.ITA.ENG.1080p.AMZN.WEB-DLMux.DD5.1.H.264-MeM.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'Marvels.Agents.of.S.H.I.E.L.D.S07E03.Comunisti.alieni.dal.futuro.ITA.ENG.1080p.AMZN.WEB-DLMux.DD5.1.H.264-MeM.mkv',
+    'seasons': list([
+      7,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[McFarland.USA.2015.1080p.BluRay.x265-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'McFarland.USA.2015.1080p.BluRay.x265-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Mission.Impossible.1996.Custom.Audio.1080p.PL-Spedboy.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Mission.Impossible.1996.Custom.Audio.1080p.PL-Spedboy.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Mixed-ish.S01E20.XviD-AFG[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      20,
+    ]),
+    'filename': 'Mixed-ish.S01E20.XviD-AFG[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Mommy (2014) French 720p BluRay x264 -[MoviesFD]]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Mommy (2014) French 720p BluRay x264 -[MoviesFD]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Monk.S08E14.1080p.HEVC.x265-MeGusta[eztv]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': list([
+      14,
+    ]),
+    'filename': 'Monk.S08E14.1080p.HEVC.x265-MeGusta[eztv]',
+    'seasons': list([
+      8,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Moothon: The Elder One (2019) Malayalam UNTOUCHED 720p WEB-DL - 2.5 GB - (DD- 2.0) ESub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'Moothon: The Elder One (2019) Malayalam UNTOUCHED 720p WEB-DL - 2.5 GB - (DD- 2.0) ESub x264 - Shadow (BonsaiHD)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Most.Expensivest.S01E01.Treat.Yo.Self.1080p.VICE.WEB-DL.AAC2.0.x264-BOOP.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Most.Expensivest.S01E01.Treat.Yo.Self.1080p.VICE.WEB-DL.AAC2.0.x264-BOOP.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Mother [Madre] (2016) BluRay - 720p - [Tamil + Hindi + Spanish] - 950MB - ESub - TamilMV]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Mother [Madre] (2016) BluRay - 720p - [Tamil + Hindi + Spanish] - 950MB - ESub - TamilMV',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Movie 43 (2013) 720p BluRay x264 -[MoviesFD]]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      43,
+    ]),
+    'filename': 'Movie 43 (2013) 720p BluRay x264 -[MoviesFD]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Mr.Mercedes.S01E01.Pilot.DTV.WEB-DL.DD2.0.x264-BTW.mkv]
+  dict({
+    'attributes': list([
+      '2.0',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Mr.Mercedes.S01E01.Pilot.DTV.WEB-DL.DD2.0.x264-BTW.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Mystery Diners S08 Season 8 Complete x265 720P]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Mystery Diners S08 Season 8 Complete x265 720P',
+    'seasons': list([
+      8,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Mystery.of.the.Lost.Islands.S01E01.Shark.Island.1080p.ANPL.WEB-DL.AAC2.0.x264-BOOP.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Mystery.of.the.Lost.Islands.S01E01.Shark.Island.1080p.ANPL.WEB-DL.AAC2.0.x264-BOOP.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[NOS4A2 (2019) Multi Audio [Hindi - Tamil - Bengali] 720p Untouched AMZN WEB-DL x264 AAC Esub - CineVood]
+  dict({
+    'attributes': list([
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'NOS4A2 (2019) Multi Audio [Hindi - Tamil - Bengali] 720p Untouched AMZN WEB-DL x264 AAC Esub - CineVood',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[NOS4A2.S02E01.720p.WEB.H264-OATH[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'NOS4A2.S02E01.720p.WEB.H264-OATH[TGx]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Naked.and.Afraid.XL.S06E00.Clothed.and.Opinionated.Part.2.720p.WEB.h264-ROBOTS[eztv]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      0,
+    ]),
+    'filename': 'Naked.and.Afraid.XL.S06E00.Clothed.and.Opinionated.Part.2.720p.WEB.h264-ROBOTS[eztv]',
+    'seasons': list([
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Near.Death.2004.1080p.BluRay.H264.AAC-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Near.Death.2004.1080p.BluRay.H264.AAC-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Nessuno sa chi io sono qui-Nadie sabe que estoy aqui (2020) ITA-SPA Ac3 5.1 WEBRip 1080p H264 [ArMor]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Nessuno sa chi io sono qui-Nadie sabe que estoy aqui (2020) ITA-SPA Ac3 5.1 WEBRip 1080p H264 [ArMor]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[New.Game.S02.CR.WEB-DL.AAC2.0.x264-HorribleSubs]
+  dict({
+    'attributes': list([
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'New.Game.S02.CR.WEB-DL.AAC2.0.x264-HorribleSubs',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[New.Girl.S07.Season.7.Complete.1080p.NF.WEB.x264-maximersk [mrsktv]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'New.Girl.S07.Season.7.Complete.1080p.NF.WEB.x264-maximersk [mrsktv]',
+    'seasons': list([
+      7,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Nicos.Menu.Mission.S01E01.WEB.h264-WEBTUBE[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Nicos.Menu.Mission.S01E01.WEB.h264-WEBTUBE[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Non-Fiction.2018.1080p.BluRay.x264-USURY]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Non-Fiction.2018.1080p.BluRay.x264-USURY',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Nowhere.Fast.S01E01.RTE.WEB-DL.AAC2.0.H.264-RTN.mkv]
+  dict({
+    'attributes': list([
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Nowhere.Fast.S01E01.RTE.WEB-DL.AAC2.0.H.264-RTN.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Nude - International Cut (2018) 720p WEB Rip Dual Audios [ HIN, MARATHI ]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+    ]),
+    'episodes': None,
+    'filename': 'Nude - International Cut (2018) 720p WEB Rip Dual Audios [ HIN, MARATHI ]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Octonauts.S04E15.The.Great.Swamp.Search.720p.DSNY.WEBRip.AAC2.0.x264-RTN.mkv]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      15,
+    ]),
+    'filename': 'Octonauts.S04E15.The.Great.Swamp.Search.720p.DSNY.WEBRip.AAC2.0.x264-RTN.mkv',
+    'seasons': list([
+      4,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[One Piece - 927 (1080p)(HEVC x265 10bit)(Multi-Subs)-Judas[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': list([
+      927,
+      27,
+    ]),
+    'filename': 'One Piece - 927 (1080p)(HEVC x265 10bit)(Multi-Subs)-Judas[TGx]',
+    'seasons': list([
+      9,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[One Shot [2014] DVDRip XViD-ViCKY]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'One Shot [2014] DVDRip XViD-ViCKY',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Oolu (2019)[Malayalam 720p HDTV  UNTOUCHED - x264 1.4GB[MB]]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Oolu (2019)[Malayalam 720p HDTV  UNTOUCHED - x264 1.4GB[MB]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Our.Girl.S05E03.HDTV.x264-RiVER[TGx]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'Our.Girl.S05E03.HDTV.x264-RiVER[TGx]',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[PENALTY (2019) Hindi HDRip - 720p - x264 - DD+5.1 - 1.3GB - ESub - TamilMV]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'PENALTY (2019) Hindi HDRip - 720p - x264 - DD+5.1 - 1.3GB - ESub - TamilMV',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Paan Singh Tomar 2012 Hindi 720p NF WEBRip x264 AAC 5.1 ESubs - LOKiHD - Telly]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Paan Singh Tomar 2012 Hindi 720p NF WEBRip x264 AAC 5.1 ESubs - LOKiHD - Telly',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Peaky.Blinders.S01.720p.BluRay.FLAC2.0.x264-DON]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Peaky.Blinders.S01.720p.BluRay.FLAC2.0.x264-DON',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Penguin (2020) Tamil 720p AMZN WEBRip \u2b501.1 GB\u2b50 AAC DD- 5.1 ESub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'aac',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Penguin (2020) Tamil 720p AMZN WEBRip ⭐1.1 GB⭐ AAC DD- 5.1 ESub x264 - Shadow (BonsaiHD)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Penguin (2020) [Tam+Tel+Mal - 720p - WEB HDRip - x264 - DD 5.1 - MSub - 2GB] - MAZE]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Penguin (2020) [Tam+Tel+Mal - 720p - WEB HDRip - x264 - DD 5.1 - MSub - 2GB] - MAZE',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Perversion (2020) full HIndi 720p Flizmovies WEB-DL x264]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Perversion (2020) full HIndi 720p Flizmovies WEB-DL x264',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Philip.K.Dicks.Electric.Dreams.S01E01.The.Hood.Maker.STAN.WEB-DL.AAC2.0.H.264-BTW.mkv]
+  dict({
+    'attributes': list([
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Philip.K.Dicks.Electric.Dreams.S01E01.The.Hood.Maker.STAN.WEB-DL.AAC2.0.H.264-BTW.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Piprabidya (2013) Bengali 720p Hoichoi WEB-DL \u2b50650 MB\u2b50 AAC DD- 2.0 ESub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'aac',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      650,
+      50,
+    ]),
+    'filename': 'Piprabidya (2013) Bengali 720p Hoichoi WEB-DL ⭐650 MB⭐ AAC DD- 2.0 ESub x264 - Shadow (BonsaiHD)',
+    'seasons': list([
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Plunderer - 23 (1080p)(HEVC x265 10bit)(Eng-Subs)-Judas[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': list([
+      23,
+    ]),
+    'filename': 'Plunderer - 23 (1080p)(HEVC x265 10bit)(Eng-Subs)-Judas[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Plunderer - 23 (360p)-HorribleSubs[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      23,
+    ]),
+    'filename': 'Plunderer - 23 (360p)-HorribleSubs[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Pok\xe9mon S02/Pokemon_-_2x05_(087)_[DVDRip-Hun-Eng].mkv]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'eng',
+      'hun',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      5,
+    ]),
+    'filename': 'Pokémon S02/Pokemon_-_2x05_(087)_[DVDRip-Hun-Eng].mkv',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Pok\xe9mon S02]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Pokémon S02',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Police.Ten.7.S27E13.HDTV.x264-FiHTV[TGx]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      13,
+    ]),
+    'filename': 'Police.Ten.7.S27E13.HDTV.x264-FiHTV[TGx]',
+    'seasons': list([
+      27,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Police.Ten.7.S27E15.HDTV.x264-FiHTV[eztv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      15,
+    ]),
+    'filename': 'Police.Ten.7.S27E15.HDTV.x264-FiHTV[eztv]',
+    'seasons': list([
+      27,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Prawaas 2020.1080p.AMZN.WEB-DL.DD+5.1.H264.Dus.IcTv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Prawaas 2020.1080p.AMZN.WEB-DL.DD+5.1.H264.Dus.IcTv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Princess Connect! Re-Dive - 11 (720p)(Multiple Subtitle)-Erai-raws[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      11,
+    ]),
+    'filename': 'Princess Connect! Re-Dive - 11 (720p)(Multiple Subtitle)-Erai-raws[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Professor Marston and the Wonder Women (2017) - H264 Ita Eng Deu Esp Ac3 5.1 Multisub - DVDRip - by SnakeSPL MIRCrew]
+  dict({
+    'attributes': list([
+      '5.1',
+      'ac3',
+      'dvd-rip',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Professor Marston and the Wonder Women (2017) - H264 Ita Eng Deu Esp Ac3 5.1 Multisub - DVDRip - by SnakeSPL MIRCrew',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Proximity.2020.1080p.Bluray.DTS-HD.MA.5.1.X264-EVO[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'bluray',
+      'dts-hd-ma',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Proximity.2020.1080p.Bluray.DTS-HD.MA.5.1.X264-EVO[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[RangiTaranga (2015) 720p Kannada movie HDRip]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'RangiTaranga (2015) 720p Kannada movie HDRip',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Rasbhari (2020) Hindi AMZN WEB-DL DD2.0 x264 AAC Esub - CineVood]
+  dict({
+    'attributes': list([
+      '2.0',
+      'aac',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Rasbhari (2020) Hindi AMZN WEB-DL DD2.0 x264 AAC Esub - CineVood',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Ready.Jet.Go.S01E12.Chore.Day.720p.PBS.WEBRip.AAC2.0.x264-SynHD.mkv]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Ready.Jet.Go.S01E12.Chore.Day.720p.PBS.WEBRip.AAC2.0.x264-SynHD.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Red.Sonja.Queen.Of.Plagues.2016.BDRip.x264-W4F[PRiME]]
+  dict({
+    'attributes': list([
+      'bdrip',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Red.Sonja.Queen.Of.Plagues.2016.BDRip.x264-W4F[PRiME]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Rendez Vous.2015.DUBBED.1080p.WEBRip.x265-R4RBG[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Rendez Vous.2015.DUBBED.1080p.WEBRip.x265-R4RBG[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Return.To.Snowy.River.1988.iNTERNAL.DVDRip.x264-W4F[PRiME]]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Return.To.Snowy.River.1988.iNTERNAL.DVDRip.x264-W4F[PRiME]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Rick.Steins.Road.To.Mexico.S01E01.720p.iP.WEB-DL.AAC2.0.H.264-RTN.mkv]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Rick.Steins.Road.To.Mexico.S01E01.720p.iP.WEB-DL.AAC2.0.H.264-RTN.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Ridoy Jure 2020 Bangla Movie HDRip 800MB ORG]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Ridoy Jure 2020 Bangla Movie HDRip 800MB ORG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Road.House.2.Last.Call.2006.Unrated.1080p.HDTV.H264.AC3.DD2.0.Will1869]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'ac3',
+      'hdtv',
+      'sdr',
+      'uncut',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'Road.House.2.Last.Call.2006.Unrated.1080p.HDTV.H264.AC3.DD2.0.Will1869',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Road.to.the.NHL.Winter.Classic.S07E01.Rangers.vs.Sabres.Part1.1080p.REPACK.NBC.WEB-DL.AAC2.0.H.264-BTW.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Road.to.the.NHL.Winter.Classic.S07E01.Rangers.vs.Sabres.Part1.1080p.REPACK.NBC.WEB-DL.AAC2.0.H.264-BTW.mkv',
+    'seasons': list([
+      7,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Robert.Kirkmans.Secret.History.of.Comics.S01E01.The.Mighty.Misfits.Who.Made.Marvel.1080p.AMC.WEB-DL.AAC2.0.H.264-BOOP.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Robert.Kirkmans.Secret.History.of.Comics.S01E01.The.Mighty.Misfits.Who.Made.Marvel.1080p.AMC.WEB-DL.AAC2.0.H.264-BOOP.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Romantic.Comedy.2019.1080p.AMZN.WEBRip.DDP2.0.x264-TEPES[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Romantic.Comedy.2019.1080p.AMZN.WEBRip.DDP2.0.x264-TEPES[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Roswell.New.Mexico.S02E04.480p.x264-ZMNT]
+  dict({
+    'attributes': list([
+      '480p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'Roswell.New.Mexico.S02E04.480p.x264-ZMNT',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Rustlers on Horseback  (Western 1950)  Allan Lane]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Rustlers on Horseback  (Western 1950)  Allan Lane',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[SHAHENSHA 2020 BANGLA MOVIE SHAKIB KHAN HDRIP]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'SHAHENSHA 2020 BANGLA MOVIE SHAKIB KHAN HDRIP',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Sacred Games 2018 S01 Complete Season 1 Hindi 720p NetFlix x264 DDP 5.1 ESub - xRG]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Sacred Games 2018 S01 Complete Season 1 Hindi 720p NetFlix x264 DDP 5.1 ESub - xRG',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Samrat & Co. (2014) Hindi 720p AMZN WEBRip \u2b501.2 GB\u2b50 2CH ESub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Samrat & Co. (2014) Hindi 720p AMZN WEBRip ⭐1.2 GB⭐ 2CH ESub x264 - Shadow (BonsaiHD)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Sarkar 3 2017 Hindi 1080p WEBRip x264 AC3 ESubs - LOKiHD - Telly]
+  dict({
+    'attributes': list([
+      '1080p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'Sarkar 3 2017 Hindi 1080p WEBRip x264 AC3 ESubs - LOKiHD - Telly',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Satyagraha (2013) (1080p BluRay x265 10bit HEVC AAC 5.1 RONIN)0]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'aac',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Satyagraha (2013) (1080p BluRay x265 10bit HEVC AAC 5.1 RONIN)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Satyagraha (2013) (1080p BluRay x265 10bit HEVC AAC 5.1 RONIN)1]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'aac',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Satyagraha (2013) (1080p BluRay x265 10bit HEVC AAC 5.1 RONIN)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Scandalous.The.Untold.Story.of.the.National.Enquirer.2020.720p.HMAX.WEBRip.800MB.x264-GalaxyRG]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Scandalous.The.Untold.Story.of.the.National.Enquirer.2020.720p.HMAX.WEBRip.800MB.x264-GalaxyRG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Scooby-Doo Goes Hollywood (1980) (1080p Dvdrip AI upscale x265 10bit AAC 1.0 - Frys) [TAoE].mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Scooby-Doo Goes Hollywood (1980) (1080p Dvdrip AI upscale x265 10bit AAC 1.0 - Frys) [TAoE].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Sea.Monsters..Series.2.Part.11.Oceans.Most.Powerful.1080p.HDTV.x264.AAC.MVGroup.org.mp4]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'Sea.Monsters..Series.2.Part.11.Oceans.Most.Powerful.1080p.HDTV.x264.AAC.MVGroup.org.mp4',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Seinfeld.S04E23E24.The.Pilot.FiNAL.MULTi.1080p.NF.WEB-DL.HE-AAC2.0.H264-Ralf.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Seinfeld.S04E23E24.The.Pilot.FiNAL.MULTi.1080p.NF.WEB-DL.HE-AAC2.0.H264-Ralf.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Shadowverse - 11 (720p)(Multiple Subtitle)-Erai-raws[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      11,
+    ]),
+    'filename': 'Shadowverse - 11 (720p)(Multiple Subtitle)-Erai-raws[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Shaman King (Season 1) (1080p)(HEVC x265 10bit)(Eng-Subs)-Judas[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Shaman King (Season 1) (1080p)(HEVC x265 10bit)(Eng-Subs)-Judas[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Shokugeki No Soma - S05E01-Judas[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Shokugeki No Soma - S05E01-Judas[TGx]',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Shrek.2.2004.1080p.BluRay.x264.YIFY.srt]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'Shrek.2.2004.1080p.BluRay.x264.YIFY.srt',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Shuddh Desi Romance 2013 Hindi 720p BluRay x264 AAC 5.1 MSubs - LOKiHD - Telly]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'aac',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Shuddh Desi Romance 2013 Hindi 720p BluRay x264 AAC 5.1 MSubs - LOKiHD - Telly',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Sin.City.A.Dame.to.Kill.For.2014.1080p.BluRay.x264-SPARKS]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Sin.City.A.Dame.to.Kill.For.2014.1080p.BluRay.x264-SPARKS',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Sons of Anarchy Season 3 Complete 1280 x 720 x264 Phun Psyz]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Sons of Anarchy Season 3 Complete 1280 x 720 x264 Phun Psyz',
+    'seasons': list([
+      3,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Sons.of.Anarchy.S01E03]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'Sons.of.Anarchy.S01E03',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Souad [2021 - Egypt] drama]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Souad [2021 - Egypt] drama',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[South Park S18E05 HDTV x264-KILLERS [eztv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      5,
+    ]),
+    'filename': 'South Park S18E05 HDTV x264-KILLERS [eztv]',
+    'seasons': list([
+      18,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[South Park Season 23 Complete 720p AMZN WEB-DL x264 [i_c]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'South Park Season 23 Complete 720p AMZN WEB-DL x264 [i_c]',
+    'seasons': list([
+      23,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Soviet Cinema - Provintsialki 1990 SATRip XviD x263-NOGROUP]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Soviet Cinema - Provintsialki 1990 SATRip XviD x263-NOGROUP',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Spider-Noir.S01.720p.AMZN.WEB-DL.DDP5.1.Atmos.H.264.HuN-TRiNiTY/Spider-Noir.S01E04.720p.AMZN.WEB-DL.DDP5.1.Atmos.H.264.HuN-TRiNiTY.mkv]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'dolby-atmos',
+      'eac3',
+      'hun',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'Spider-Noir.S01.720p.AMZN.WEB-DL.DDP5.1.Atmos.H.264.HuN-TRiNiTY/Spider-Noir.S01E04.720p.AMZN.WEB-DL.DDP5.1.Atmos.H.264.HuN-TRiNiTY.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Spider-Noir.S01.720p.AMZN.WEB-DL.DDP5.1.Atmos.H.264.HuN-TRiNiTY]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'dolby-atmos',
+      'eac3',
+      'hun',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Spider-Noir.S01.720p.AMZN.WEB-DL.DDP5.1.Atmos.H.264.HuN-TRiNiTY',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Split.Image.1982.Xvid.Eng.ETRG]
+  dict({
+    'attributes': list([
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Split.Image.1982.Xvid.Eng.ETRG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[SpongeBob.SquarePants.S02.iT.WEB-DL.AAC2.0.H.264-NOGRP]
+  dict({
+    'attributes': list([
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'SpongeBob.SquarePants.S02.iT.WEB-DL.AAC2.0.H.264-NOGRP',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Spring.Night.Summer.Night.1967.BDRip.x264-GHOULS[TGx]]
+  dict({
+    'attributes': list([
+      'bdrip',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Spring.Night.Summer.Night.1967.BDRip.x264-GHOULS[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Star.Trek.Discovery.S01E01.The.Vulcan.Hello.540p.CBS.WEB-DL.AAC2.0.x264-AJP69.mkv]
+  dict({
+    'attributes': list([
+      '2.0',
+      '540p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Star.Trek.Discovery.S01E01.The.Vulcan.Hello.540p.CBS.WEB-DL.AAC2.0.x264-AJP69.mkv',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Starhunter.ReduX.S02.1080p.AMZN.WEBRip.DDP5.1.x264-GLUE[rartv]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Starhunter.ReduX.S02.1080p.AMZN.WEBRip.DDP5.1.x264-GLUE[rartv]',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Stephen.Colbert.2020.04.02.Alicia.Keys.HDTV.x264-SORNY[TGx]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'Stephen.Colbert.2020.04.02.Alicia.Keys.HDTV.x264-SORNY[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Stephen.Colbert.2020.06.23.John.Bolton.720p.HDTV.x264-SORNY[eztv]]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'Stephen.Colbert.2020.06.23.John.Bolton.720p.HDTV.x264-SORNY[eztv]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Steven Universe]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Steven Universe',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Still A Mystery S01 WEBRip x264-CAFFEiNE]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Still A Mystery S01 WEBRip x264-CAFFEiNE',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Sugarfoot (Action Western 1951) Randolph Scott]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Sugarfoot (Action Western 1951) Randolph Scott',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Superman.2025.2160p.MA.WEB-DL.DDP5.1.Atmos.H.265.HUN-FULCRUM/fulcrum-superman.2025.2160p.web.ma.mkv]
+  dict({
+    'attributes': list([
+      '2160p',
+      '5.1',
+      'dolby-atmos',
+      'eac3',
+      'hun',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Superman.2025.2160p.MA.WEB-DL.DDP5.1.Atmos.H.265.HUN-FULCRUM/fulcrum-superman.2025.2160p.web.ma.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Superman.2025.2160p.MA.WEB-DL.DDP5.1.Atmos.H.265.HUN-FULCRUM]
+  dict({
+    'attributes': list([
+      '2160p',
+      '5.1',
+      'dolby-atmos',
+      'eac3',
+      'hun',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'Superman.2025.2160p.MA.WEB-DL.DDP5.1.Atmos.H.265.HUN-FULCRUM',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Swinki [2009 - Poland] drama]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Swinki [2009 - Poland] drama',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Tamayomi - 12 (360p)-HorribleSubs[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Tamayomi - 12 (360p)-HorribleSubs[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Teenage Mutant Ninja Turtles (HdRip / 2014)]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Teenage Mutant Ninja Turtles (HdRip / 2014)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Teenage Mutant Ninja Turtles (unknown_release_type / 2014)]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Teenage Mutant Ninja Turtles (unknown_release_type / 2014)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Teenage.Mutant.Ninja.Turtles.2014.720p.HDRip.x264.AC3.5.1-RARBG]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Teenage.Mutant.Ninja.Turtles.2014.720p.HDRip.x264.AC3.5.1-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Teenage.Mutant.Ninja.Turtles.2014.HDRip.XviD.MP3-RARBG]
+  dict({
+    'attributes': list([
+      'aac',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Teenage.Mutant.Ninja.Turtles.2014.HDRip.XviD.MP3-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The 11th Hour with Brian Williams 2020 06 23 1080p WEBRip x265 HEVC-LM]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x265',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'The 11th Hour with Brian Williams 2020 06 23 1080p WEBRip x265 HEVC-LM',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Amazing Spider-Man 2 2014 720p BluRay Hindi English x264 AAC 5.1 MSubs - LOKiHD - Telly]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'aac',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'The Amazing Spider-Man 2 2014 720p BluRay Hindi English x264 AAC 5.1 MSubs - LOKiHD - Telly',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Amazing World of Gumball]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Amazing World of Gumball',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Beat with Ari Melber 2020 06 19 720p WEBRip x264-PC.mp4]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'The Beat with Ari Melber 2020 06 19 720p WEBRip x264-PC.mp4',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Best Offer.mkv]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Best Offer.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Big Bang Theory S08E06 HDTV XviD-LOL [eztv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'The Big Bang Theory S08E06 HDTV XviD-LOL [eztv]',
+    'seasons': list([
+      8,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Big Bus - Il fantabus (1976).720p.H264.ita.eng.Ac3.sub.ita.eng-MIRCrew]
+  dict({
+    'attributes': list([
+      '720p',
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Big Bus - Il fantabus (1976).720p.H264.ita.eng.Ac3.sub.ita.eng-MIRCrew',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Bridge (Bron Broen) S01 Season 1 BRRip x264 AAC E-Subs [GWC]]
+  dict({
+    'attributes': list([
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Bridge (Bron Broen) S01 Season 1 BRRip x264 AAC E-Subs [GWC]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Deep Blue Sea - Drama 2011 Eng Rus Multi-Subs 720p [H264-mp4]]
+  dict({
+    'attributes': list([
+      '720p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Deep Blue Sea - Drama 2011 Eng Rus Multi-Subs 720p [H264-mp4]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Djinn 2021 1080p BRRip DD5 1 X 264-EVO]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'The Djinn 2021 1080p BRRip DD5 1 X 264-EVO',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Flash 2014 S01E01 HDTV x264-LOL[ettv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'The Flash 2014 S01E01 HDTV x264-LOL[ettv]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Flash 2014 S01E03 HDTV x264-LOL[ettv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'The Flash 2014 S01E03 HDTV x264-LOL[ettv]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Flash 2014 S01E04 HDTV x264-FUM[ettv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'The Flash 2014 S01E04 HDTV x264-FUM[ettv]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Flintstones (1960) S06 (1080p HMAX Webrip x265 10bit AC3 2.0 - Goki)[TAoE]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'The Flintstones (1960) S06 (1080p HMAX Webrip x265 10bit AC3 2.0 - Goki)[TAoE]',
+    'seasons': list([
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Four (2012) BluRay - 720p - [Telugu + Tamil + Hindi + Chi] - 1.1GB - ESub - TamilMV]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'The Four (2012) BluRay - 720p - [Telugu + Tamil + Hindi + Chi] - 1.1GB - ESub - TamilMV',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The French Connection (1971) Remastered 1080p BluRay x265 HEVC EAC3-SARTRE]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'eac3',
+      'remastered',
+      'sdr',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'The French Connection (1971) Remastered 1080p BluRay x265 HEVC EAC3-SARTRE',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Fresh Prince of Bel-Air (1990) S01 REPACK (1080p NF Webrip x265 10bit AC3 2.0 - DNU) [TAoE]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'The Fresh Prince of Bel-Air (1990) S01 REPACK (1080p NF Webrip x265 10bit AC3 2.0 - DNU) [TAoE]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Fxxk-It List (2020) [English+Hindi - 720p - WEB HDRip - x264 - DD 5.1 - MSub - 2GB] - MAZE]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Fxxk-It List (2020) [English+Hindi - 720p - WEB HDRip - x264 - DD 5.1 - MSub - 2GB] - MAZE',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Good German (2006).VOSTFR.720p.WEBDL.h264.aac.mkv]
+  dict({
+    'attributes': list([
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Good German (2006).VOSTFR.720p.WEBDL.h264.aac.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Hand Bag (2020) HDRip x264 - SHADOW[TGx]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Hand Bag (2020) HDRip x264 - SHADOW[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Hateful Eight (2015) 720p BluRay - x265 HEVC - 999MB - ShAaN]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'The Hateful Eight (2015) 720p BluRay - x265 HEVC - 999MB - ShAaN',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Hunt (2020) BluRay 1080p.H264 Ita Eng AC3 5.1 Sub Ita Eng MIRCrew]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Hunt (2020) BluRay 1080p.H264 Ita Eng AC3 5.1 Sub Ita Eng MIRCrew',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Inbetweeners Complete Collection]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Inbetweeners Complete Collection',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The King of Comedy 1982 DVD9 PAL-iCMAL]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The King of Comedy 1982 DVD9 PAL-iCMAL',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Kissing Bandit (Comedy West. 1948) Frank Sinatra 720p HD]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Kissing Bandit (Comedy West. 1948) Frank Sinatra 720p HD',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Martian 2015 540p HDRip KORSUB x264 AAC2 0-FGT]
+  dict({
+    'attributes': list([
+      '540p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      0,
+    ]),
+    'filename': 'The Martian 2015 540p HDRip KORSUB x264 AAC2 0-FGT',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Missing 1x01 Pilot HDTV x264-FoV [eztv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'The Missing 1x01 Pilot HDTV x264-FoV [eztv]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Mouse on the Moon [1963 - UK] comedy]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Mouse on the Moon [1963 - UK] comedy',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Painted Bird (2019) Interslavic 720p Bluray \u2b501.3 GB\u2b50 DD- 2.0 ESub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'ac3',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'The Painted Bird (2019) Interslavic 720p Bluray ⭐1.3 GB⭐ DD- 2.0 ESub x264 - Shadow (BonsaiHD)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Peacemaker (1997)Mp-4-X264-Dvd-Rip-480p-AAC-DSD]
+  dict({
+    'attributes': list([
+      '480p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'The Peacemaker (1997)Mp-4-X264-Dvd-Rip-480p-AAC-DSD',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Purge: Election Year (2016) HC - 720p HDRiP - 900MB - ShAaNi]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Purge: Election Year (2016) HC - 720p HDRiP - 900MB - ShAaNi',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Shaukeens (2014) 1CD DvDScr Rip x264 [DDR]]
+  dict({
+    'attributes': list([
+      'cam',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Shaukeens (2014) 1CD DvDScr Rip x264 [DDR]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Shaukeens 2014 Hindi (1CD) DvDScr x264 AAC...Hon3y]
+  dict({
+    'attributes': list([
+      'aac',
+      'cam',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Shaukeens 2014 Hindi (1CD) DvDScr x264 AAC...Hon3y',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Simpsons - Complete Seasons S01 to S28 (1080p, 720p, DVDRip)]
+  dict({
+    'attributes': list([
+      '1080p',
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Simpsons - Complete Seasons S01 to S28 (1080p, 720p, DVDRip)',
+    'seasons': list([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25,
+      26,
+      27,
+      28,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Simpsons - Season 1 Complete [DVDrip ITA ENG] TNT Village]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Simpsons - Season 1 Complete [DVDrip ITA ENG] TNT Village',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Simpsons S26E05 HDTV x264 PROPER-LOL [eztv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      5,
+    ]),
+    'filename': 'The Simpsons S26E05 HDTV x264 PROPER-LOL [eztv]',
+    'seasons': list([
+      26,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Sopranos - The Complete Series (Season 1, 2, 3, 4, 5 & 6) + Extras]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The Sopranos - The Complete Series (Season 1, 2, 3, 4, 5 & 6) + Extras',
+    'seasons': list([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Thin Blue Line 1995 S01-S02 Complete DVDRip H264 BONE]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The Thin Blue Line 1995 S01-S02 Complete DVDRip H264 BONE',
+    'seasons': list([
+      1,
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Twilight Saga Breaking Dawn - Part 2 (2012) (1080p BDRip x265 10bit DTS-HD MA 7.1 - r0b0t) [TAoE].mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '7.1',
+      'bdrip',
+      'dts-hd-ma',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'The Twilight Saga Breaking Dawn - Part 2 (2012) (1080p BDRip x265 10bit DTS-HD MA 7.1 - r0b0t) [TAoE].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Twilight Saga: Breaking Down - Parte 2 (2012) - 720p H264 Ita Eng DTS HD Masters 5.1 Sub Ita Eng by SnakeSPL MIRCrew]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'dts-hd-ma',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      2,
+    ]),
+    'filename': 'The Twilight Saga: Breaking Down - Parte 2 (2012) - 720p H264 Ita Eng DTS HD Masters 5.1 Sub Ita Eng by SnakeSPL MIRCrew',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The Walking Dead S05E03 720p HDTV x264-ASAP[ettv]]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'The Walking Dead S05E03 720p HDTV x264-ASAP[ettv]',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Blacklist.S07e05-06.ITA.ENG.1080p.AMZN.WEB-DLMux.DD5.1.H264-MeM]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      5,
+      6,
+    ]),
+    'filename': 'The.Blacklist.S07e05-06.ITA.ENG.1080p.AMZN.WEB-DLMux.DD5.1.H264-MeM',
+    'seasons': list([
+      7,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Boondocks.S02.HUN.DVDRip.XviD-HSF/hsf-bndcks-201.avi]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'hun',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      201,
+      1,
+    ]),
+    'filename': 'The.Boondocks.S02.HUN.DVDRip.XviD-HSF/hsf-bndcks-201.avi',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Boondocks.S02.HUN.DVDRip.XviD-HSF]
+  dict({
+    'attributes': list([
+      'dvd-rip',
+      'hun',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The.Boondocks.S02.HUN.DVDRip.XviD-HSF',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Boss.2016.UNRATED.720p.BRRip.x264.AAC-ETRG]
+  dict({
+    'attributes': list([
+      '720p',
+      'aac',
+      'sdr',
+      'uncut',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Boss.2016.UNRATED.720p.BRRip.x264.AAC-ETRG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Flash.2014.S03.720p.HDTV.x264-Scene]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Flash.2014.S03.720p.HDTV.x264-Scene',
+    'seasons': list([
+      3,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Flash.2014.S06E13.Il.mio.amico.Grodd.Repack.ITA.ENG.1080p.AMZN.WEB-DLMux.H.264-MeM.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'eng',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      13,
+    ]),
+    'filename': 'The.Flash.2014.S06E13.Il.mio.amico.Grodd.Repack.ITA.ENG.1080p.AMZN.WEB-DLMux.H.264-MeM.mkv',
+    'seasons': list([
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Gentlemen.2019.576p.DQLDR.BRRIP]
+  dict({
+    'attributes': list([
+      '576p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'The.Gentlemen.2019.576p.DQLDR.BRRIP',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Jungle.Book.2016.3D.1080p.BRRip.SBS.x264.AAC-ETRG]
+  dict({
+    'attributes': list([
+      '1080p',
+      '3d',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Jungle.Book.2016.3D.1080p.BRRip.SBS.x264.AAC-ETRG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Killer.Truth.S01E05.Homicide.at.Home.HDTV.x264-CRiMSON[TGx]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      5,
+    ]),
+    'filename': 'The.Killer.Truth.S01E05.Homicide.at.Home.HDTV.x264-CRiMSON[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Last.Word.with.Lawrence.O'Donnell.2020.06.18.540p.WEBDL-Anon]
+  dict({
+    'attributes': list([
+      '540p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': "The.Last.Word.with.Lawrence.O'Donnell.2020.06.18.540p.WEBDL-Anon",
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Legend.of.1900.1998.1080p.BluRay.H264.AAC-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Legend.of.1900.1998.1080p.BluRay.H264.AAC-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Lord.of.the.Rings.Extended.Edition.2001.1080p.BluRay.x264.DTS-WiKi]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'dts',
+      'extended',
+      'sdr',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Lord.of.the.Rings.Extended.Edition.2001.1080p.BluRay.x264.DTS-WiKi',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Meg.2018.1080p.HDRip.x264.[ExYu-Subs]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Meg.2018.1080p.HDRip.x264.[ExYu-Subs]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Rachel.Maddow.Show.2020.06.18.540p.WEBDL-Anon]
+  dict({
+    'attributes': list([
+      '540p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'The.Rachel.Maddow.Show.2020.06.18.540p.WEBDL-Anon',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Rachel.Maddow.Show.2020.06.18.720p.MNBC.WEB-DL.AAC2.0.H.264-BTW[TGx]]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'The.Rachel.Maddow.Show.2020.06.18.720p.MNBC.WEB-DL.AAC2.0.H.264-BTW[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Red.Pony.1949.1080p.BluRay.H264.AAC-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Red.Pony.1949.1080p.BluRay.H264.AAC-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Rule.for.a.Vagabond.1965.JAPANESE.ENSUBBED.1080p.WEBRip.x265-VXT]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'The.Rule.for.a.Vagabond.1965.JAPANESE.ENSUBBED.1080p.WEBRip.x265-VXT',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Secret.Life.of.Pets.2016.HDRiP.AAC-LC.x264-LEGi0N]
+  dict({
+    'attributes': list([
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Secret.Life.of.Pets.2016.HDRiP.AAC-LC.x264-LEGi0N',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Shivering.Truth.S01.1080p.AS.WEB-DL.AAC2.0.H.264-BTN]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.Shivering.Truth.S01.1080p.AS.WEB-DL.AAC2.0.H.264-BTN',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Walking.Dead.S05E03.1080p.WEB-DL.DD5.1.H.264-Cyphanix[rartv]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'The.Walking.Dead.S05E03.1080p.WEB-DL.DD5.1.H.264-Cyphanix[rartv]',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.Walking.Dead.S06E07.SUBFRENCH.HDTV.x264-AMB3R.mkv]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      7,
+    ]),
+    'filename': 'The.Walking.Dead.S06E07.SUBFRENCH.HDTV.x264-AMB3R.mkv',
+    'seasons': list([
+      6,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.X-Files.Complete.S01-S09.1080p.BluRay.x264-GECKOS]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.X-Files.Complete.S01-S09.1080p.BluRay.x264-GECKOS',
+    'seasons': list([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.X-Files.S01-S03.DKsubs.1080p.BluRay.HEVC.x265]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'The.X-Files.S01-S03.DKsubs.1080p.BluRay.HEVC.x265',
+    'seasons': list([
+      1,
+      2,
+      3,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[The.X-Files.S01.Retail.DKsubs.720p.BluRay.x264-RAPiDCOWS]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'The.X-Files.S01.Retail.DKsubs.720p.BluRay.x264-RAPiDCOWS',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[These.Final.Hours.2013.WBBRip XViD]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'These.Final.Hours.2013.WBBRip XViD',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Thirteen S01 MultiSub 720p x264-StB]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Thirteen S01 MultiSub 720p x264-StB',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Tower of God - 12 (480p)-HorribleSubs[TGx]]
+  dict({
+    'attributes': list([
+      '480p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Tower of God - 12 (480p)-HorribleSubs[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Trackers.S01E03.PROPER.720p.WEB.H264-GHOSTS[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'Trackers.S01E03.PROPER.720p.WEB.H264-GHOSTS[TGx]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Treasure Planet 2002 1080p FLAC MKV (oan)]
+  dict({
+    'attributes': list([
+      '1080p',
+      'flac',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Treasure Planet 2002 1080p FLAC MKV (oan)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Trishas.Southern.Kitchen.S16E12.Family.Favorites.with.Allie.iNTERNAL.WEB.h264-ROBOTS[eztv]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'Trishas.Southern.Kitchen.S16E12.Family.Favorites.with.Allie.iNTERNAL.WEB.h264-ROBOTS[eztv]',
+    'seasons': list([
+      16,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Tsugumomo S2 - 12 (720p)-HorribleSubs[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Tsugumomo S2 - 12 (720p)-HorribleSubs[TGx]',
+    'seasons': list([
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Tulips in Spring 2016 Hallmark 720p HDRip X264 Solar]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Tulips in Spring 2016 Hallmark 720p HDRip X264 Solar',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Turtle Odyssey (2019) 1080p 5.1 - 2.0 x264 Phun Psyz]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Turtle Odyssey (2019) 1080p 5.1 - 2.0 x264 Phun Psyz',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Two and a Half Men S12E01 HDTV x264 REPACK-LOL [eztv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'Two and a Half Men S12E01 HDTV x264 REPACK-LOL [eztv]',
+    'seasons': list([
+      12,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[UFC.179.PPV.HDTV.x264-Ebi[rartv]]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      179,
+      79,
+    ]),
+    'filename': 'UFC.179.PPV.HDTV.x264-Ebi[rartv]',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Vacancy (2007) 720p Bluray Dual Audio [Hindi + English] \u2b50800 MB\u2b50 DD - 2.0 MSub x264 - Shadow (BonsaiHD)]
+  dict({
+    'attributes': list([
+      '2.0',
+      '720p',
+      'ac3',
+      'bluray',
+      'eng',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      800,
+      0,
+    ]),
+    'filename': 'Vacancy (2007) 720p Bluray Dual Audio [Hindi + English] ⭐800 MB⭐ DD - 2.0 MSub x264 - Shadow (BonsaiHD)',
+    'seasons': list([
+      8,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Valeries.Home.Cooking.S11E10.Lights.Camera.Eat.iNTERNAL.720p.WEB.h264-ROBOTS[eztv]]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': list([
+      10,
+    ]),
+    'filename': 'Valeries.Home.Cooking.S11E10.Lights.Camera.Eat.iNTERNAL.720p.WEB.h264-ROBOTS[eztv]',
+    'seasons': list([
+      11,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[WWE Hell in a Cell 2014 HDTV x264 SNHD]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'WWE Hell in a Cell 2014 HDTV x264 SNHD',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[WWE Hell in a Cell 2014 PPV WEB-DL x264-WD -={SPARROW}=-]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'WWE Hell in a Cell 2014 PPV WEB-DL x264-WD -={SPARROW}=-',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[WWE Monday Night Raw 2014 11 10 WS PDTV x264-RKOFAN1990 -={SPARR]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      11,
+    ]),
+    'filename': 'WWE Monday Night Raw 2014 11 10 WS PDTV x264-RKOFAN1990 -={SPARR',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[WWE Monday Night Raw 3rd Nov 2014 HDTV x264-Sir Paul]
+  dict({
+    'attributes': list([
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'WWE Monday Night Raw 3rd Nov 2014 HDTV x264-Sir Paul',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[WWE.Monday.Night.RAW.2020-06-16.German.720p.HDTV.x264-SPORTY[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'WWE.Monday.Night.RAW.2020-06-16.German.720p.HDTV.x264-SPORTY[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[War Dogs (2016) HDTS 600MB - NBY]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'War Dogs (2016) HDTS 600MB - NBY',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[War.2019.LIMITED.720p.BluRay.x264-Chakra[TGx]]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'War.2019.LIMITED.720p.BluRay.x264-Chakra[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Wasp Network (2019) HDRip 720p [Hindi-Dub] Dual-Audio x264]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Wasp Network (2019) HDRip 720p [Hindi-Dub] Dual-Audio x264',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Wasp Network (2020) ITA-ENG Ac3 5.1 WEBRip 1080p H264 [ArMor]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Wasp Network (2020) ITA-ENG Ac3 5.1 WEBRip 1080p H264 [ArMor]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[We Were Soldiers 2002 720p BluRay HEVC H265 BONE]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'We Were Soldiers 2002 720p BluRay HEVC H265 BONE',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[We.Summon.The.Darkness.2020.1080p.Bluray.Atmos.TrueHD.7.1.x264-EVO[TGx]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '7.1',
+      'bluray',
+      'dolby-atmos',
+      'sdr',
+      'theatrical',
+      'truehd',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'We.Summon.The.Darkness.2020.1080p.Bluray.Atmos.TrueHD.7.1.x264-EVO[TGx]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Weekend at Bernie's II (1993) [1080p]  [BluRay] [YTS]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bluray',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': "Weekend at Bernie's II (1993) [1080p]  [BluRay] [YTS]",
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[What.If...2010.1080p.WEB-DL.DDP2.0.H264.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'What.If...2010.1080p.WEB-DL.DDP2.0.H264.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[When Bjork Met Attenborough (2013) (1080p BluRay x265 HEVC 10bit AC3 2.0 Silence) [QxR]]
+  dict({
+    'attributes': list([
+      '1080p',
+      '2.0',
+      'ac3',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'When Bjork Met Attenborough (2013) (1080p BluRay x265 HEVC 10bit AC3 2.0 Silence) [QxR]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[When Sparks Fly 2014 Hallmark 720P HDTV X264 Solar]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'When Sparks Fly 2014 Hallmark 720P HDTV X264 Solar',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Wild Target (2010)Mp-4-X264-Dvd-Rip-480p-AAC-DSD]
+  dict({
+    'attributes': list([
+      '480p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      4,
+    ]),
+    'filename': 'Wild Target (2010)Mp-4-X264-Dvd-Rip-480p-AAC-DSD',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Workaholics.S07.1080p.CC.WEBRip.AAC2.0.x264-BTW]
+  dict({
+    'attributes': list([
+      '1080p',
+      '7.1',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Workaholics.S07.1080p.CC.WEBRip.AAC2.0.x264-BTW',
+    'seasons': list([
+      7,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[X-Men.2000.REMASTERED.BRRip.XviD.B4ND1T69]
+  dict({
+    'attributes': list([
+      'remastered',
+      'sdr',
+    ]),
+    'episodes': None,
+    'filename': 'X-Men.2000.REMASTERED.BRRip.XviD.B4ND1T69',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[X-Men.Days.of.Future.Past.2014.1080p.WEB-DL.DD5.1.H264-RARBG]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'X-Men.Days.of.Future.Past.2014.1080p.WEB-DL.DD5.1.H264-RARBG',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[X-men The Last Stand (2006) (1080p BluRay x265 HEVC 10bit AAC 6.1 Vyndros)]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': 'X-men The Last Stand (2006) (1080p BluRay x265 HEVC 10bit AAC 6.1 Vyndros)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[X2.X-Men.United.2003.REMASTERED.BRRip.XviD.B4ND1T69]
+  dict({
+    'attributes': list([
+      'remastered',
+      'sdr',
+    ]),
+    'episodes': None,
+    'filename': 'X2.X-Men.United.2003.REMASTERED.BRRip.XviD.B4ND1T69',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[Your Honor 2020 S01 Hindi 720p WEBRip x264 AAC ESubs - LOKiHD - Telly]
+  dict({
+    'attributes': list([
+      '720p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'web-rip',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'Your Honor 2020 S01 Hindi 720p WEBRip x264 AAC ESubs - LOKiHD - Telly',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[Z Nation (2014)S01-01-13 (2014) Full Season.XviD - Italian English.Ac3.Sub.ita.eng.MIRCrew]
+  dict({
+    'attributes': list([
+      'ac3',
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'Z Nation (2014)S01-01-13 (2014) Full Season.XviD - Italian English.Ac3.Sub.ita.eng.MIRCrew',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[ www.Speed.cd ] -Sons.of.Anarchy.S07E07.720p.HDTV.X264-DIMENSION]
+  dict({
+    'attributes': list([
+      '720p',
+      'hdtv',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      7,
+    ]),
+    'filename': '[ www.Speed.cd ] -Sons.of.Anarchy.S07E07.720p.HDTV.X264-DIMENSION',
+    'seasons': list([
+      7,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[[06] Documentry -BBC - The Ottomans: Europe's Muslim Emperors (2013) eng.ara sub [Etcohod]]
+  dict({
+    'attributes': list([
+      'eng',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      6,
+    ]),
+    'filename': "[06] Documentry -BBC - The Ottomans: Europe's Muslim Emperors (2013) eng.ara sub [Etcohod]",
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[720pMkv.Com]_sons.of.anarchy.s05e10.480p.BluRay.x264-GAnGSteR]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      10,
+    ]),
+    'filename': '[720pMkv.Com]_sons.of.anarchy.s05e10.480p.BluRay.x264-GAnGSteR',
+    'seasons': list([
+      5,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[[Anonymous] Non Non Biyori [BD 1080p 10bit H.264 FLAC]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'flac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': '[Anonymous] Non Non Biyori [BD 1080p 10bit H.264 FLAC]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[Arjix] Darling in the Franxx [BD-Remux]]
+  dict({
+    'attributes': list([
+      'remux',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': '[Arjix] Darling in the Franxx [BD-Remux]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[BDremux] One Piece Movies Collection]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': '[BDremux] One Piece Movies Collection',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[CBT] Nisekoi S1+S2 [BDrip 1920x1080 x264 FLAC]]
+  dict({
+    'attributes': list([
+      '1080p',
+      'bdrip',
+      'flac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': '[CBT] Nisekoi S1+S2 [BDrip 1920x1080 x264 FLAC]',
+    'seasons': list([
+      1,
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[[Erai-raws] Arte - 12 END [720p].mkv]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': '[Erai-raws] Arte - 12 END [720p].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[Erai-raws] Honzuki no Gekokujou - Shisho ni Naru Tame ni wa Shudan wo Erandeiraremasen 2nd Season - 12 END [1080p][Multiple Subtitle].mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': '[Erai-raws] Honzuki no Gekokujou - Shisho ni Naru Tame ni wa Shudan wo Erandeiraremasen 2nd Season - 12 END [1080p][Multiple Subtitle].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[Erai-raws] Yesterday o Utatte - 12 END [720p][Multiple Subtitle].mkv]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': '[Erai-raws] Yesterday o Utatte - 12 END [720p][Multiple Subtitle].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[FFF-Remux][Batch] Accel World 1-24 Dual-Audio 1080p FLAC]
+  dict({
+    'attributes': list([
+      '1080p',
+      'flac',
+      'remux',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': '[FFF-Remux][Batch] Accel World 1-24 Dual-Audio 1080p FLAC',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[Golumpa] Blood Blockade Battlefront & Beyond - 08 (Kekkai Sensen & Beyond) [FuniDub 1080p x264 AAC] [78481C9C].mkv (1.4 GB)]
+  dict({
+    'attributes': list([
+      '1080p',
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      8,
+    ]),
+    'filename': '[Golumpa] Blood Blockade Battlefront & Beyond - 08 (Kekkai Sensen & Beyond) [FuniDub 1080p x264 AAC] [78481C9C].mkv (1.4 GB)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[JySzE] Naruto [v2] [R2J] [VFR] [Dual Audio] [Complete] [Extras] [x264]]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': '[JySzE] Naruto [v2] [R2J] [VFR] [Dual Audio] [Complete] [Extras] [x264]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[YURI] Kimi no Suizou o Tabetai [BD1080p HEVC FLAC][Dual Audio]  v4]
+  dict({
+    'attributes': list([
+      '1080p',
+      'flac',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': '[YURI] Kimi no Suizou o Tabetai [BD1080p HEVC FLAC][Dual Audio]  v4',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[[zooqle.com] Parks and Recreation S02 Season 2 720p 5.1Ch Web-DL ReEnc-DeeJayAhmed]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+    ]),
+    'episodes': None,
+    'filename': '[zooqle.com] Parks and Recreation S02 Season 2 720p 5.1Ch Web-DL ReEnc-DeeJayAhmed',
+    'seasons': list([
+      2,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[breaking.bad.s01e01.720p.bluray.x264-reward]
+  dict({
+    'attributes': list([
+      '720p',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'breaking.bad.s01e01.720p.bluray.x264-reward',
+    'seasons': list([
+      1,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[doctor_who_2005.8x12.death_in_heaven.720p_hdtv_x264-fov]
+  dict({
+    'attributes': list([
+      '720p',
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': list([
+      12,
+    ]),
+    'filename': 'doctor_who_2005.8x12.death_in_heaven.720p_hdtv_x264-fov',
+    'seasons': list([
+      8,
+    ]),
+  })
+# ---
+# name: test_torrent_parser_snapshots[liz.and.the.blue.bird.2018.japanese.1080p.bluray.dd5.1.hevc.x265.rmteam.mkv]
+  dict({
+    'attributes': list([
+      '1080p',
+      '5.1',
+      'ac3',
+      'bluray',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'liz.and.the.blue.bird.2018.japanese.1080p.bluray.dd5.1.hevc.x265.rmteam.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[tick.tick...BOOM.mp4]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'tick.tick...BOOM.mp4',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[www.1TamilBlasters.art - Sultan of Delhi (2023) S01EP(01-09) [HQ HDRip - x264 - [Tam + Mal + Tel + Kan] - AAC - 1.2GB - ESub]]
+  dict({
+    'attributes': list([
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      1,
+    ]),
+    'filename': 'www.1TamilBlasters.art - Sultan of Delhi (2023) S01EP(01-09) [HQ HDRip - x264 - [Tam + Mal + Tel + Kan] - AAC - 1.2GB - ESub]',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[www.1TamilBlasters.lat - Thuritham (2023) [Tamil - 2K QHD AVC UNTOUCHED - x264 - AAC - 3.4GB - ESub].mkv]
+  dict({
+    'attributes': list([
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': list([
+      3,
+    ]),
+    'filename': 'www.1TamilBlasters.lat - Thuritham (2023) [Tamil - 2K QHD AVC UNTOUCHED - x264 - AAC - 3.4GB - ESub].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[www.1TamilBlasters.sbs - Lucky Man (2023) [Tamil - 720p HQ HDRip - HEVC - x265 - [DDP5.1 (192Kbps) + AAC] - 900MB - ESub].mkv]
+  dict({
+    'attributes': list([
+      '5.1',
+      '720p',
+      'aac',
+      'eac3',
+      'sdr',
+      'theatrical',
+      'x265',
+    ]),
+    'episodes': None,
+    'filename': 'www.1TamilBlasters.sbs - Lucky Man (2023) [Tamil - 720p HQ HDRip - HEVC - x265 - [DDP5.1 (192Kbps) + AAC] - 900MB - ESub].mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[www.1TamilMV.world - Kotha Rangula Prapancham (2024) Telugu HQ PreDVD - 700MB - x264 - HQ Clean Aud.mkv]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'www.1TamilMV.world - Kotha Rangula Prapancham (2024) Telugu HQ PreDVD - 700MB - x264 - HQ Clean Aud.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[www.1TamilMV.world - Raja Vikramarka (2024) Tamil HQ HDRip - 400MB - x264 - AAC - ESub.mkv]
+  dict({
+    'attributes': list([
+      'aac',
+      'sdr',
+      'theatrical',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'www.1TamilMV.world - Raja Vikramarka (2024) Tamil HQ HDRip - 400MB - x264 - AAC - ESub.mkv',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[www.Torrenting.com   -    Anatomy Of A Fall (2023)]
+  dict({
+    'attributes': list([
+      'sdr',
+      'theatrical',
+    ]),
+    'episodes': None,
+    'filename': 'www.Torrenting.com   -    Anatomy Of A Fall (2023)',
+    'seasons': None,
+  })
+# ---
+# name: test_torrent_parser_snapshots[www.Torrenting.com - Presque.2021.FRENCH.1080p.WEB.H264-SEiGHT]
+  dict({
+    'attributes': list([
+      '1080p',
+      'sdr',
+      'theatrical',
+      'web-dl',
+      'x264',
+    ]),
+    'episodes': None,
+    'filename': 'www.Torrenting.com - Presque.2021.FRENCH.1080p.WEB.H264-SEiGHT',
+    'seasons': None,
+  })
+# ---


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>nCore felbontás-/nyelvfelismerés, többévados tartomány-parszolás és mappa-alapú évadcsomagok javítása</h1>
<h2>Összefoglaló</h2>
<p>Három egymástól független hiba, amikre annak kiderítése közben bukkantam,
hogy miért nem jelentek meg bizonyos nCore torrentek (elsősorban a
többévados csomagok) találatként a Nuvióban, holott jól szídelt, helyesen
kategorizált release-ekről volt szó:</p>
<ol>
<li><strong><code>ncore.py</code></strong>: a felbontást és a nyelvet kizárólag a durva nCore
kategória-tagből (pl. <code>hdser_hun</code>) határozta meg, nem a tényleges release
névből - emiatt minden "HD" kategóriás torrent <code>720p</code>-nek látszott, még
akkor is, ha valójában <code>1080p</code> vagy <code>2160p</code> volt.</li>
<li><strong><code>series_parser.py</code></strong>: a <code>_parse_season_list</code> némán elhasalt minden
olyan évad-tartományon, ahol a tartomány MÁSIK vége is <code>S</code>/<code>Season</code>
előtaggal szerepelt (pl. <code>S01-S04</code>, <code>S01 to S28</code>) - ez egy rendkívül
gyakori elnevezési konvenció -, és <code>seasons: None</code>-t adott vissza a
helyes tartomány helyett.</li>
<li><strong><code>stream_file_resolver.py</code></strong>: a torrenten belüli fájlok évad/epizód
egyeztetésekor kizárólag a fájl NEVÉT nézte (mappa nélkül). Azoknál a
csomagoknál, ahol a fájlok mappánként vannak rendezve és az évadszám
KIZÁRÓLAG a mappa nevében szerepel (pl. <code>S01/EP01 (...).mkv</code> - gyakori
anime release-eknél), ez azt jelentette, hogy egyetlen fájl évada sem
volt felismerhető - ami a #2-es hibával kombinálva azt eredményezte,
hogy az így szervezett többévados csomagok SOHA, SEMMILYEN epizódra nem
tudtak találatot adni.</li>
</ol>
<p>Mindhárom hiba javítva lett, mindegyikhez regressziós teszttel. Egyéb
viselkedésbeli változás nincs, kivéve azt a hat meglévő teszt-snapshotot,
amikben ténylegesen hibás érték volt "elvárt eredményként" rögzítve (lásd
lentebb: "Snapshot-változások").</p>
<hr>
<h2>1. hiba — Durva, kategória-alapú felbontás-/nyelvfelismerés</h2>
<p><strong>Fájl:</strong> <code>server/app/modules/indexer_definitions/integrations/ncore.py</code></p>
<h3>Előtte</h3>
<pre><code class="language-python">def _resolve_resolution(self, category: str) -&gt; str:
    if "hd" in category:
        return MediaAttributeKey.R720P
    return MediaAttributeKey.R480P

def _resolve_language(self, category: str) -&gt; str:
    if "hun" in category:
        return MediaAttributeKey.HUN
    return MediaAttributeKey.ENG
</code></pre>
<p>Az nCore saját kategória-rendszere kategória szinten csak "HD" vs. "SD"
(illetve magyar vs. nem magyar szinkron) megkülönböztetésre képes - nincs
külön kategóriája a 720p/1080p/2160p-nek. A régi kód minden <code>hd*</code>
kategóriájú torrentet <code>720p</code>-ként kezelt, ami egyszerűen hibás, amikor a
release valójában 1080p vagy 2160p.</p>
<h3>Reprodukálás (a valós nCore API válaszból, "Miraculous" keresésre)</h3>

torrent_id | kategória | release_name (részlet) | régi eredmény | valódi
-- | -- | -- | -- | --
3658581 | hdser_hun | ...S05.1080p.DSNP.WEB-DL... | 720p ❌ | 1080p
3329383 | hdser_hun | ...S01-S04 1080p | 720p ❌ | 1080p
4141751 | hdser | ...S06.Part1.1080p... | 720p ❌ | 1080p
3080646 | hdser | ...2020.1080p.HULU... | 720p ❌ | 1080p


<h3>Utána</h3>
<pre><code class="language-python">def _resolve_attribute_ids(self, category: str, release_name: str) -&gt; list[str]:
    category_fallback_ids = [
        self._resolve_resolution_from_category(category),
        self._resolve_language_from_category(category),
    ]
    external_fallbacks = resolve_attribute_ids(category_fallback_ids)

    parsed_attributes = parse_torrent_name(
        release_name, external_fallbacks=external_fallbacks
    )
    return [attribute.id for attribute in parsed_attributes]
</code></pre>
<p>Mostantól a <code>parse_torrent_name()</code> közvetlenül a tényleges release névből
nyeri ki a felbontást/nyelvet. A kategória-alapú becslés csak tartalékként
(a <code>parse_torrent_name</code> saját <code>external_fallbacks</code> mechanizmusán keresztül)
kerül felhasználásra - arra az (nCore-on egyáltalán nem ritka) esetre, amikor
a release névben nincs explicit felbontás- vagy nyelv-jelölés (pl.
<code>Miraculous - Katicabogár és Fekete Macska kalandjai S04</code> - magyar című
release "HUN" jelölés nélkül, ahol a kategória <code>_hun</code> végződése az EGYETLEN
nyelvi jelzés).</p>
<p><strong>Megjegyzés az <code>external_fallbacks</code> vs. <code>use_fallbacks</code> kapcsán:</strong> a javítás
első verziója a <code>parse_torrent_name(release_name, use_fallbacks=False)</code>
hívást használta, saját kézzel írt kategória-fallback logikával kiegészítve.
Ez elhasalt az élesben futó, publikált <code>s4pp1/stremhu-source:latest</code> Docker
image-en, aminek a <code>parse_torrent_name()</code> függvénye nem is ismeri a
<code>use_fallbacks</code> paramétert - csak az <code>external_fallbacks</code>-ot, ami mindkét
verzióban jelen van. A jelenlegi megoldás kizárólag az <code>external_fallbacks</code>-ot
használja, ami mindkettővel kompatibilis, és egyszerűbb is, mivel a "volt-e
találat a névben ehhez a kategóriához" ellenőrzést magára a
<code>parse_torrent_name()</code>-re bízza, nem próbálja újraimplementálni.</p>
<hr>
<h2>2. hiba — Többévados tartományok (<code>S01-S04</code>) parszolása némán elhasalt</h2>
<p><strong>Fájl:</strong> <code>server/app/modules/torrent_streams/utils/series_parser.py</code></p>
<h3>Előtte</h3>
<pre><code class="language-python">def _parse_season_list(s: str) -&gt; list[int]:
    ...
    for token in tokens:
        token = token.strip().lower()
        token = re.sub(r"^(?:seasons?|s)", "", token)  # csak a token ELEJÉRŐL vágja le az előtagot

        range_match = re.match(r"^(\d{1,2})-(\d{1,2})$", token)
        ...
</code></pre>
<p>A <code>PATTERN_SEASON_LIST</code> helyesen KIFOGJA az olyan szövegrészeket, mint pl.
<code>01-s04</code> az <code>S01-S04</code> bemenetből, de a <code>_parse_season_list</code> csak a token
LEGELEJÉRŐL vágta le az <code>s</code>/<code>season</code> előtagot. Egy <code>01-s04</code>-hez hasonló
tartománynál a MÁSODIK határ még mindig hordozza az <code>s</code> előtagot, így a
<code>range_match</code> (ami mindkét oldalon tiszta számjegyeket vár) soha nem
illeszkedett, és a token némán elveszett - ez okozta a teljes találatra a
<code>seasons: None</code> eredményt.</p>
<h3>Reprodukálás</h3>
<p>Ez egy elterjedt, általános elnevezési minta, nem csak nCore-specifikus
szélsőséges eset. Megerősítve a repóban már meglévő teszt-fixture-ön is:</p>
<pre><code>Malcolm.in.the.Middle.S01-S07.COMPLETE.READ.NFO.576p.NF.WEBRip.DD5.1.x264.HUN.ENG-pcroland
  -&gt; seasons: None   (HIBÁS — helyesen [1,2,3,4,5,6,7] kellene legyen)
</code></pre>
<p>A <code>test_torrent_parsers.ambr</code>-ben rögzített snapshot ezt a hibás értéket
"elvárt eredményként" tartalmazta - a tesztsuite 418/418-cal zöld volt úgy,
hogy közben aktívan kódolta be a hibát.</p>
<p>További, javítás előtt megerősítetten hibás minták:</p>
<pre><code>The.X-Files.S01-S03.DKsubs.1080p.BluRay.HEVC.x265        -&gt; None
The.X-Files.Complete.S01-S09.1080p.BluRay.x264-GECKOS     -&gt; None
American Dad! S01 - S13 Complete                          -&gt; None
The Simpsons - Complete Seasons S01 to S28 (...)           -&gt; None
The Thin Blue Line 1995 S01-S02 Complete DVDRip H264 BONE  -&gt; None
Miraculous - Katicabogár és Fekete Macska kalandjai S01-S04 720p  -&gt; None
</code></pre>
<h3>Utána</h3>
<pre><code class="language-python">range_match = re.match(
    r"^(?:seasons?|s)?(\d{1,2})-(?:seasons?|s)?(\d{1,2})$", token
)
if range_match:
    seasons.extend(_expand_range(range_match.group(1), range_match.group(2)))
    continue

num_match = re.match(r"^(?:seasons?|s)?(\d{1,2})$", token)
if num_match:
    seasons.append(int(num_match.group(1)))
</code></pre>
<p>A tartomány mindkét határa most már egymástól függetlenül elfogad opcionális
<code>s</code>/<code>season</code> előtagot, így illeszkedik <code>01-s04</code>, <code>s01-04</code>, <code>s01-s04</code>,
<code>01 to s28</code> stb. formátumokra is. A fenti összes minta mostantól helyesen
felismerésre kerül (ellenőrizve - lásd a "Tesztelés" szekciót).</p>
<hr>
<h2>3. hiba — Fájlonkénti évadfelismerés figyelmen kívül hagyja a mappa-elérési utat</h2>
<p><strong>Fájl:</strong> <code>server/app/modules/torrent_streams/utils/stream_file_resolver.py</code></p>
<p>Ez okozta ténylegesen, hogy a Miraculous többévados csomagjai a #2-es hiba
javítása UTÁN sem jelentek meg a Nuvióban.</p>
<h3>A háttér</h3>
<p>A <code>TorrentFileInfo.name</code> mezőből a mappa-komponens le van vágva, már a
parszolás pillanatában (<code>server/app/common/torrent_info.py</code>):</p>
<pre><code class="language-python">name = file_entry.path.split("/")[-1]
</code></pre>
<p>A <code>TorrentFileInfo.path</code> viszont megtartja a teljes relatív elérési utat.</p>
<p>Valós fájllista egy tényleges nCore torrentből (<code>S01-S04 1080p</code> csomag):</p>
<pre><code>S01/[Anime-BD] Miraculous - Tales of Ladybug and Cat Noir EP01 (Netflix WEB-DL 1920x1080 x264 Multi-Audio).mkv
S02/[Anime-BD] Miraculous - Tales of Ladybug and Cat Noir 2 EP01 (Netflix WEB-DL 1920x1080 x264 Dual-Audio).mkv
...
</code></pre>
<p>Az évadszám KIZÁRÓLAG a mappa nevében szerepel (<code>S01/</code>, <code>S02/</code>...) - a
fájlnévben soha, ott csak <code>EPxx</code> van.</p>
<h3>Előtte</h3>
<pre><code class="language-python">for file in valid_files:
    file_name_cleaned = clean_torrent_name(file.name)   # a mappa már le van vágva
    file_seasons, file_episodes = parse_season_episode(file_name_cleaned)

    if not file_episodes or series.episode not in file_episodes:
        continue

    if file_seasons:
        if series.season in file_seasons:
            return file
    else:
        if torrent_seasons and len(torrent_seasons) == 1 and series.season in torrent_seasons:
            ...
</code></pre>
<p>Mivel a <code>file.name</code> sosem tartalmazza a mappát, az így szervezett csomagok
minden fájljánál a <code>file_seasons</code> mindig <code>None</code> volt. A fallback ág csak
akkor aktiválódik, ha maga a TORRENT EGÉSZE pontosan egy évadot fed le
(<code>len(torrent_seasons) == 1</code>) - ami definíció szerint hamis bármelyik
többévados csomagnál. Nettó hatás: <strong>az így szervezett többévados csomagban
egyetlen fájl sem tud SOHA egyezni, SEMMILYEN évad/epizódra</strong> - a #2-es hiba
javításától teljesen függetlenül.</p>
<p>Közvetlenül megerősítve:</p>
<pre><code class="language-python">&gt;&gt;&gt; parse_season_episode(clean_torrent_name("[Anime-BD] Miraculous - Tales of Ladybug and Cat Noir EP01 (Netflix WEB-DL 1920x1080 x264 Multi-Audio).mkv"))
(None, [1])   # évad elveszett

&gt;&gt;&gt; parse_season_episode(clean_torrent_name("S01/[Anime-BD] Miraculous - Tales of Ladybug and Cat Noir EP01 (Netflix WEB-DL 1920x1080 x264 Multi-Audio).mkv"))
([1], [1])    # helyes
</code></pre>
<p>Érdemes megjegyezni: a <code>parse_season_episode</code> MÁR ELEVE úgy lett megírva,
hogy teljes elérési utat várjon - az utolsó mentsváras "magányos számjegy
mint epizód" fallback-je kifejezetten <code>filename_lower.split("/")[-1]</code>-et
hajt végre, kimondottan azért, hogy a mappanevek ne szennyezzék be ezt a
kockázatos találgatást, miközben minden korábbi (biztonságosabb)
évadfelismerő lépés szándékosan a TELJES stringen dolgozik. A
<code>stream_file_resolver.py</code> egyszerűen nem használta ki ezt azzal, hogy nem a
teljes elérési utat adta át.</p>
<h3>Utána</h3>
<pre><code class="language-python">for file in valid_files:
    # a file.path-ot használjuk (nem a file.name-et) szándékosan: a
    # file.name-ből le van vágva a mappa-komponens, de sok évadcsomag
    # évadonkénti almappákba van rendezve, ahol az évadszám csak a
    # mappában szerepel (pl. "S01/EP01.mkv"), a fájlnévben soha. A
    # parse_season_episode már eleve úgy lett megírva, hogy teljes
    # elérési utat kapjon - csak a kockázatos "magányos számjegy mint
    # epizód" fallback-nél vágja le a szülőmappát, az évadfelismerésnél
    # szándékosan megtartja.
    file_name_cleaned = clean_torrent_name(file.path)
    file_seasons, file_episodes = parse_season_episode(file_name_cleaned)
</code></pre>
<p>Egysoros változás (<code>file.name</code> → <code>file.path</code>). Mivel a <code>file.path</code> mindig
szuperhalmaza a <code>file.name</code>-nek (ugyanaz a string, opcionális mappa-előtaggal
kiegészítve), ez szigorúan csak információt ad hozzá - nem tud elvenni olyan
információt, amitől egy korábban helyes találat függött volna.</p>
<hr>
<h2>Tesztelés</h2>
<ul>
<li>Helyi venv-et állítottam fel a <code>main</code> branch tényleges függőségeivel
(beleértve a <code>libtorrent</code>-et is), és lefuttattam a meglévő tesztsuite-ot
alapállapotként: <strong>418/418 zöld</strong> a <code>test_torrent_parsers.py</code>-on (474
összesen a teljes suite-ban) - még mielőtt bármihez hozzányúltam volna,
hogy megerősítsem: a meglévő viselkedés (a hibákkal együtt) teljesen le
van fedve a snapshot suite-tal.</li>
<li>Javítottam a 2. hibát, újra lefuttattam a suite-ot. <strong>6 snapshot bukott
el</strong> - mind a hat eset <code>seasons: None</code> volt egy <code>SXX-SYY</code> típusú
tartományra, ami pontosan a hiba. Frissítettem a snapshotokat a helyes
értékekre (<code>--snapshot-update</code>), és diff-eltem, hogy megerősítsem: TÉNYLEG
csak ez a 6 <code>seasons</code> mező változott, semmi más.</li>
<li>Létrehoztam a <code>server/tests/test_ncore_indexer.py</code>-t (43 új teszt): a
"Miraculous"-ra kapott valós, 12 elemes nCore API mintaválaszra
paraméterezve (felbontás, nyelv és évad-asszerciók torrentenként), plusz
célzott regressziós tesztek a felbontás-vs-kategória prioritásra és
egy tucat különböző alakú többévados tartományra (kétjegyű határok,
<code>to</code>-vel elválasztott, <code>season</code> szóval, csökkenő tartományok,
vesszős listák, túlméretezett tartományok stb.).</li>
<li>Új regressziós tesztet adtam a <code>server/tests/test_stream_file_resolver.py</code>-hoz
(<code>test_resolve_series_season_pack_with_season_only_in_folder_name</code>), ami
a Miraculous torrent valós mappastruktúráját reprodukálja, negatív esettel
is kiegészítve (egy, a csomagban nem szereplő évad helyesen nem ad
találatot, nem hamis pozitívot).</li>
<li>Kiderült, hogy a MEGLÉVŐ többévados-csomag teszt ebben a fájlban valójában
sosem tesztelte ezt az esetet, mert a fixture-je véletlenül a fájlnévben
is megismételte az évadszámot a mappa mellett
(<code>S02/The.Show.S02E04.mkv</code>) - ez a véletlen egybeesés fedte el eddig a
hibát.</li>
<li>Végállapot: <strong>470/470 teszt zöld</strong>, <code>ruff check</code> / <code>ruff format --check</code>
/ <code>basedpyright</code> mind tiszta minden módosított fájlon.</li>
<li>Éles környezetben, végponttól végpontig is ellenőrizve: mindhárom javítás
alkalmazása után a korábban láthatatlan 720p/1080p többévados csomagok
helyesen megjelennek plusz stream-forrásként a Nuvióban egy 1. évad 1.
epizód keresésnél.</li>
</ul>
<h2>Módosított fájlok</h2>
<ul>
<li><code>server/app/modules/indexer_definitions/integrations/ncore.py</code></li>
<li><code>server/app/modules/torrent_streams/utils/series_parser.py</code></li>
<li><code>server/app/modules/torrent_streams/utils/stream_file_resolver.py</code></li>
<li><code>server/tests/test_ncore_indexer.py</code> (új)</li>
<li><code>server/tests/test_stream_file_resolver.py</code></li>
<li><code>server/tests/__snapshots__/test_torrent_parsers.ambr</code> (6 javított érték)</li>
</ul></body></html><!--EndFragment-->
</body>
</html>