### PR TITLE
HunTorrent: böngésző oldal parse (táblázatos ÉS poszter-nézet)

### DIFF
--- a/server/app/modules/indexer_definitions/integrations/huntorrent.py
+++ b/server/app/modules/indexer_definitions/integrations/huntorrent.py
@@ -78,6 +78,34 @@ def _parse_torrent_id(href: str | None) -> str | None:
     return None
 
 
+def _parse_poster_id(poster_id: str | None) -> str | None:
+    # A sor azonosítója az id attribútumban van, "poster-" előtaggal:
+    # id="poster-53357".
+    if not poster_id:
+        return None
+
+    prefix, _, torrent_id = poster_id.partition("poster-")
+    if prefix or not torrent_id.isdigit():
+        return None
+
+    return torrent_id
+
+
+def _parse_seeders(item: Node) -> int:
+    # A seed érték a "Seed" feliratú .poster-stat blokkban van; az értéket egy
+    # <a> csomagolja, ezért csak a számjegyeket olvassuk ki.
+    for stat in item.css(".poster-stat"):
+        label = stat.css_first(".poster-stat-label")
+        if label is None or "seed" not in label.text().lower():
+            continue
+
+        value = stat.css_first(".poster-stat-value")
+        digits = "".join(ch for ch in value.text() if ch.isdigit()) if value else ""
+        return int(digits) if digits else 0
+
+    return 0
+
+
 class HunTorrentIndexerDefinition(BaseIndexerDefinition):
     @property
     def id(self) -> str:
@@ -191,23 +219,24 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
         tree = HTMLParser(response.text)
         torrents: list[IndexerDefinitionTorrent] = []
 
-        for row in tree.css("tr.torrent-row"):
-            torrent_id = row.attributes.get("data-torrent-id")
+        # A böngésző-oldal poszter-rácsot használ: minden torrent egy
+        # div.poster-item, az azonosítója az id="poster-<id>" attribútumban.
+        for item in tree.css("div.poster-item"):
+            torrent_id = _parse_poster_id(item.attributes.get("id"))
             if not torrent_id:
                 continue
 
             # A letöltési link már tartalmazza a felhasználó torrent_pass-át.
-            download_node = row.css_first('.torrent-meta a[href*="/download/"]')
+            download_node = item.css_first('.poster-actions a[href*="/download/"]')
             download_path = _get_attribute(download_node, "href")
             if not download_path:
                 continue
 
-            category_node = row.css_first(".torrent-category img")
-            category = (_get_attribute(category_node, "alt") or "").strip().lower()
+            category_node = item.css_first(".poster-category span")
+            category = (category_node.text() if category_node else "").strip().lower()
 
-            imdb_node = row.css_first('a[href*="imdb.com/title/"]')
+            imdb_node = item.css_first('a[href*="imdb.com/title/"]')
             row_imdb_id = _parse_imdb_id(_get_attribute(imdb_node, "href"))
-            seeders = row.attributes.get("data-seeders") or ""
 
             torrents.append(
                 IndexerDefinitionTorrent(
@@ -218,7 +247,7 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
                     # azonosítót írnánk, akkor az IMDB link nélküli sorok is
                     # átcsúsznának a szűrőn.
                     imdb_id=row_imdb_id,
-                    seeders=int(seeders) if seeders.isdigit() else 0,
+                    seeders=_parse_seeders(item),
                     attribute_ids=_CATEGORY_ATTRIBUTES.get(category, []),
                 )
             )

--- a/server/app/modules/indexer_definitions/integrations/huntorrent.py
+++ b/server/app/modules/indexer_definitions/integrations/huntorrent.py
@@ -217,10 +217,59 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
         )
 
         tree = HTMLParser(response.text)
+
+        # A böngésző oldal fiókfüggő nézetet ad: van táblázatos (tr.torrent-row)
+        # és poszter-rács (div.poster-item) elrendezés is. Mindkettőt kezeljük,
+        # így a keresés akkor is működik, ha a fiók bármelyik nézeten van.
+        torrents = self._parse_table_rows(tree) or self._parse_poster_items(tree)
+
+        return IndexerDefinitionFindTorrentsResult(
+            torrents=torrents,
+            next_page=self._resolve_next_page(tree, current_page),
+        )
+
+    def _parse_table_rows(self, tree: HTMLParser) -> list[IndexerDefinitionTorrent]:
+        # Táblázatos nézet: soronként egy tr.torrent-row, az adatok data-*
+        # attribútumokban (data-torrent-id, data-seeders), a kategória a
+        # .torrent-category img alt szövegében.
         torrents: list[IndexerDefinitionTorrent] = []
 
-        # A böngésző-oldal poszter-rácsot használ: minden torrent egy
-        # div.poster-item, az azonosítója az id="poster-<id>" attribútumban.
+        for row in tree.css("tr.torrent-row"):
+            torrent_id = row.attributes.get("data-torrent-id")
+            if not torrent_id:
+                continue
+
+            # A letöltési link már tartalmazza a felhasználó torrent_pass-át.
+            download_node = row.css_first('.torrent-meta a[href*="/download/"]')
+            download_path = _get_attribute(download_node, "href")
+            if not download_path:
+                continue
+
+            category_node = row.css_first(".torrent-category img")
+            category = (_get_attribute(category_node, "alt") or "").strip().lower()
+
+            imdb_node = row.css_first('a[href*="imdb.com/title/"]')
+            row_imdb_id = _parse_imdb_id(_get_attribute(imdb_node, "href"))
+            seeders = row.attributes.get("data-seeders") or ""
+
+            torrents.append(
+                IndexerDefinitionTorrent(
+                    torrent_id=torrent_id,
+                    download_url=urljoin(self.url, download_path),
+                    imdb_id=row_imdb_id,
+                    seeders=int(seeders) if seeders.isdigit() else 0,
+                    attribute_ids=_CATEGORY_ATTRIBUTES.get(category, []),
+                )
+            )
+
+        return torrents
+
+    def _parse_poster_items(self, tree: HTMLParser) -> list[IndexerDefinitionTorrent]:
+        # Poszter-rács nézet: minden torrent egy div.poster-item, az azonosító
+        # az id="poster-<id>" attribútumban, a kategória a .poster-category span
+        # szövegében, a seed a "Seed" feliratú .poster-stat blokkban.
+        torrents: list[IndexerDefinitionTorrent] = []
+
         for item in tree.css("div.poster-item"):
             torrent_id = _parse_poster_id(item.attributes.get("id"))
             if not torrent_id:
@@ -242,20 +291,13 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
                 IndexerDefinitionTorrent(
                     torrent_id=torrent_id,
                     download_url=urljoin(self.url, download_path),
-                    # Csak a ténylegesen kiolvasott azonosító megy vissza: a
-                    # _find_all() erre szűri a találatokat, és ha ide a keresett
-                    # azonosítót írnánk, akkor az IMDB link nélküli sorok is
-                    # átcsúsznának a szűrőn.
                     imdb_id=row_imdb_id,
                     seeders=_parse_seeders(item),
                     attribute_ids=_CATEGORY_ATTRIBUTES.get(category, []),
                 )
             )
 
-        return IndexerDefinitionFindTorrentsResult(
-            torrents=torrents,
-            next_page=self._resolve_next_page(tree, current_page),
-        )
+        return torrents
 
     async def _fetch_torrent(
         self,


### PR DESCRIPTION
## Probléma

A HunTorrent `/browse/` oldala kétféle, **fiókfüggő** elrendezést ad:
- **táblázatos** nézet — `tr.torrent-row`, `data-torrent-id`/`data-seeders` attribútumok, `.torrent-category img` alt;
- **poszter-rács** nézet — `div.poster-item`, `.poster-*` szelektorok.

A korábbi indexer (#242) csak a régi táblázatos markupra épült, ami a poszter-nézeten **némán nulla találatot** adott; a poszter-only megközelítés viszont a táblázat-nézeten bukna el. Belépett, engedélyezett állapotban is 0 találat, hibaüzenet nélkül (nincs `/login` átirányítás, nincs `loginForm`).

Élő szerveren ellenőrizve: az egyik fiók `tr.torrent-row: 13 | poster-item: 0`, a másik fordítva; a parser mindkettőn a teljes találati listát kiolvassa (id, letöltési link, kategória, IMDb, seed).

## Megoldás

A `_fetch_torrents` **mindkét elrendezést** kezeli:
- `_parse_table_rows` — táblázatos nézet,
- `_parse_poster_items` — poszter-rács nézet,
- előbb táblázatot próbál, ha üres, poszter-rácsot.

Így a keresés a fiók nézet-beállításától függetlenül működik. A keresési paraméterek és a `_resolve_next_page` (`a.ht-pager-btn`) változatlanok. Csak a `huntorrent.py`-t érinti.

> Az IPv4-transport fix külön PR-ben megy (#245), ez a PR attól független.