### PR TITLE
HunTorrent: IPv4-re kötött HTTP kliens a reCAPTCHA-zár ellen

### DIFF
--- a/server/app/modules/indexer_definitions/integrations/huntorrent.py
+++ b/server/app/modules/indexer_definitions/integrations/huntorrent.py
@@ -10,6 +10,7 @@ from selectolax.parser import HTMLParser, Node
 
 from app.modules.indexer_definitions.base_indexer_definition import (
     BaseIndexerDefinition,
+    IndexerClient,
 )
 from app.modules.indexer_definitions.enums import AuthenticationErrorEnum
 from app.modules.indexer_definitions.schemas.internal import (
@@ -79,6 +80,25 @@ def _parse_torrent_id(href: str | None) -> str | None:
 
 
 class HunTorrentIndexerDefinition(BaseIndexerDefinition):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # A HunTorrent reCAPTCHA-számlálója IP alapú. Ha a szerver IPv6-on megy
+        # ki, a kézi (böngészős, jellemzően IPv4-es) belépés nem az app
+        # forgalmára oldja fel a captchát, így az automata login végleg elakad.
+        # Ezért a klienst IPv4-re kötjük (local_address="0.0.0.0"), hogy az app
+        # ugyanarról az IPv4 címről menjen, mint a böngésző.
+        base_client = self._client
+        self._client = IndexerClient(
+            definition=self,
+            base_url=self.url,
+            follow_redirects=True,
+            headers=base_client.headers,
+            timeout=base_client.timeout,
+            transport=httpx.AsyncHTTPTransport(local_address="0.0.0.0"),
+        )
+        self._client.cookies.update(base_client.cookies)
+
     @property
     def id(self) -> str:
         return "huntorrent"

--- a/server/app/modules/indexer_definitions/integrations/huntorrent.py
+++ b/server/app/modules/indexer_definitions/integrations/huntorrent.py
@@ -174,9 +174,22 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
         # számláló nagyobb nullánál, azaz volt már sikertelen próbálkozás.
         # Olyankor egyszer kézzel, böngészőből kell belépni.
         form = await self._client.get(self.login_path)
-        csrf_node = HTMLParser(form.text).css_first('input[name="csrf_token"]')
+        form_tree = HTMLParser(form.text)
+        csrf_node = form_tree.css_first('input[name="csrf_token"]')
 
-        return await self._client.post(
+        # A reCAPTCHA-t az automata bejelentkezés nem tudja megoldani (nem megy
+        # g-recaptcha-response a kérésben), ezért a belépés biztosan elbukik.
+        # Ezt külön jelezzük: a sima "sikertelen bejelentkezés" alapján nagyon
+        # nehéz kideríteni, hogy valójában captcha-zár van.
+        if form_tree.css_first(".g-recaptcha, [data-sitekey]") is not None:
+            self.logger.warning(
+                "%s: a bejelentkező oldal reCAPTCHA-t kér, az automata "
+                "bejelentkezés így nem fog sikerülni. Lépj be egyszer kézzel, "
+                "böngészőből, ugyanazzal a fiókkal és ugyanarról az IP-ről.",
+                self.name,
+            )
+
+        response = await self._client.post(
             _LOGIN_API_PATH,
             data={
                 "action": "login",
@@ -187,6 +200,29 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
+
+        # A bejelentkezés eredményének naplózása. A hibát warning szinten írjuk,
+        # mert prod módban csak az látszik; a jelszó soha nem kerül logba.
+        try:
+            wrong = response.json().get("wrong") is True
+        except ValueError:
+            wrong = True
+
+        if wrong:
+            self.logger.warning(
+                "%s: sikertelen bejelentkezés (felhasználó: %s) – az oldal "
+                "elutasította a hitelesítő adatokat.",
+                self.name,
+                credential.username,
+            )
+        else:
+            self.logger.info(
+                "%s: sikeres bejelentkezés (felhasználó: %s).",
+                self.name,
+                credential.username,
+            )
+
+        return response
 
     async def _fetch_torrents(
         self,


### PR DESCRIPTION
## Probléma

A HunTorrent reCAPTCHA-számlálója **IP alapú**. Ha a szerver **IPv6-on** megy ki (a `getaddrinfo` globális IPv6 esetén alapból az IPv6-ot preferálja), akkor a **kézi böngészős belépés (IPv4)** nem az app forgalmára oldja fel a captchát — így az automata `_login` véglegesen elakad: `AuthenticationException: Sikertelen bejelentkezés a(z) HunTorrent fiókba.`.

Élő szerveren ellenőrizve: a stremhu `2001:...` (IPv6) forrás IP-ről ment ki, a böngésző IPv4-ről → a HunTorrent két külön IP-t látott, a kézi belépés nem oldotta fel a captchát az app forgalmára.

## Megoldás

Az indexer az `__init__`-ben a saját `IndexerClient`-jét **IPv4-re kötött transporttal** építi újra (`httpx.AsyncHTTPTransport(local_address="0.0.0.0")`), a base kliens fejléceit/timeout-ját és cookie-jait átvéve. Így az app **ugyanarról az IPv4 címről** megy ki, mint a böngésző.

- Nem igényel base class módosítást (az `IndexerClient` importálható).
- Nincs szükség host oldali `extra_hosts`/DNS hackre.
- Csak a `huntorrent.py`-t érinti (+20 sor), a keresés/parse logikát nem.

> Megjegyzés: a poster-grid parse-javítás külön PR-ben megy (#244), ez a PR attól független, közvetlenül a `main`-re alapozva.