### PR TITLE
HunTorrent: diagnosztika – parse- és bejelentkezés-naplózás

### DIFF
--- a/server/app/modules/indexer_definitions/integrations/huntorrent.py
+++ b/server/app/modules/indexer_definitions/integrations/huntorrent.py
@@ -182,9 +182,22 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
         # számláló nagyobb nullánál, azaz volt már sikertelen próbálkozás.
         # Olyankor egyszer kézzel, böngészőből kell belépni.
         form = await self._client.get(self.login_path)
-        csrf_node = HTMLParser(form.text).css_first('input[name="csrf_token"]')
+        form_tree = HTMLParser(form.text)
+        csrf_node = form_tree.css_first('input[name="csrf_token"]')
 
-        return await self._client.post(
+        # A reCAPTCHA-t az automata bejelentkezés nem tudja megoldani (nem megy
+        # g-recaptcha-response a kérésben), ezért a belépés biztosan elbukik.
+        # Ezt külön jelezzük: a sima "sikertelen bejelentkezés" alapján nagyon
+        # nehéz kideríteni, hogy valójában captcha-zár van.
+        if form_tree.css_first(".g-recaptcha, [data-sitekey]") is not None:
+            self.logger.warning(
+                "%s: a bejelentkező oldal reCAPTCHA-t kér, az automata "
+                "bejelentkezés így nem fog sikerülni. Lépj be egyszer kézzel, "
+                "böngészőből, ugyanazzal a fiókkal és ugyanarról az IP-ről.",
+                self.name,
+            )
+
+        response = await self._client.post(
             _LOGIN_API_PATH,
             data={
                 "action": "login",
@@ -195,6 +208,29 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
+
+        # A bejelentkezés eredményének naplózása. A hibát warning szinten írjuk,
+        # mert prod módban csak az látszik; a jelszó soha nem kerül logba.
+        try:
+            wrong = response.json().get("wrong") is True
+        except ValueError:
+            wrong = True
+
+        if wrong:
+            self.logger.warning(
+                "%s: sikertelen bejelentkezés (felhasználó: %s) – az oldal "
+                "elutasította a hitelesítő adatokat.",
+                self.name,
+                credential.username,
+            )
+        else:
+            self.logger.info(
+                "%s: sikeres bejelentkezés (felhasználó: %s).",
+                self.name,
+                credential.username,
+            )
+
+        return response
 
     async def _fetch_torrents(
         self,
@@ -222,6 +258,17 @@ class HunTorrentIndexerDefinition(BaseIndexerDefinition):
         # és poszter-rács (div.poster-item) elrendezés is. Mindkettőt kezeljük,
         # így a keresés akkor is működik, ha a fiók bármelyik nézeten van.
         torrents = self._parse_table_rows(tree) or self._parse_poster_items(tree)
+
+        # Ha a lapon vannak torrentek, de egyik parser sem illeszkedett, akkor
+        # az oldal markupja megváltozott. Enélkül a keresés némán nulla
+        # találatot adna: se hiba, se log, csak "nincs találat" — ezt nagyon
+        # nehéz kideríteni.
+        if not torrents and "/download/" in response.text:
+            self.logger.warning(
+                "%s: a böngésző oldal torrenteket tartalmaz, de egyik parser "
+                "sem illeszkedett – valószínűleg megváltozott a markup.",
+                self.name,
+            )
 
         return IndexerDefinitionFindTorrentsResult(
             torrents=torrents,


### PR DESCRIPTION
Két néma hibaforrás volt a HunTorrent indexerben, amit csak hosszas nyomozással lehetett kideríteni. Mindkettőre logolás kerül, hogy legközelebb az első kereséskor kiderüljön.

## 1. Néma nulla találat parse-hibánál

Ha az oldal markupja megváltozik, a keresés **némán nulla találatot** ad: nincs hiba, nincs log, csak „nincs találat" — miközben a felhasználó be van lépve és a lapon ott a 13 torrent. (A táblázat → poszter-rács átállásnál pontosan ez történt.)

Mostantól warning szól, ha egyik parser sem illeszkedett, **de a válaszban van letöltési link** (tehát a lapon vannak torrentek):
```
WARNING  HunTorrent: a böngésző oldal torrenteket tartalmaz, de egyik parser
         sem illeszkedett – valószínűleg megváltozott a markup.
```

## 2. Néma bejelentkezési hiba

A felületen csak *„Sikertelen bejelentkezés"* látszott, a logban semmi. Nem derült ki, hogy **reCAPTCHA-zár** van-e (amit az automata login nem tud megoldani, mert nem megy `g-recaptcha-response` a kérésben), vagy tényleg rossz a jelszó.

- ha a bejelentkező oldalon reCAPTCHA van, warning figyelmeztet, hogy egyszer kézzel, böngészőből kell belépni ugyanarról az IP-ről;
- a bejelentkezés eredménye is naplózódik: hiba `warning`, siker `info` szinten.

## Megjegyzések

- **A jelszó soha nem kerül logba**, csak a felhasználónév.
- `warning` szint, mert prod módban `log_level="warning"` (`run.py`), tehát ott is látszik.
- Csak a `huntorrent.py`-t érinti, viselkedést nem változtat — kizárólag naplóz.