### PR TITLE
feat: send videoSize in stream behaviorHints

### DIFF
--- a/server/app/modules/stremio/schemas.py
+++ b/server/app/modules/stremio/schemas.py
@@ -137,6 +137,7 @@ class BehaviorHints(BaseModel):
     not_web_ready: bool = True
     binge_group: str | None = None
     filename: str | None = None
+    video_size: int | None = None
 
 
 class StremioStream(BaseModel):
@@ -167,6 +168,7 @@ class StremioStream(BaseModel):
                         if isinstance(attr, MediaAttributeModel)
                     ],
                 ),
+                video_size=torrent_stream.file_size,
             ),
         )
 
@@ -258,6 +260,7 @@ class StremioStream(BaseModel):
             behavior_hints=BehaviorHints(
                 filename=behavior_filename,
                 binge_group=binge_group,
+                video_size=torrent_stream.file_size,
             ),
         )
 


### PR DESCRIPTION
AIOStream-ben wrappelem a Stremhu-t. Azt vettem észre, hogy nem látszik se a bitráta se a file méret:

<img width="450" height="429" alt="Screenshot 2026-08-15 at 21 16 00" src="https://github.com/user-attachments/assets/85acd47c-22c6-4213-aecc-e8a6d748ed23" />

Ez azért van mert a Stremhu nem küldi a file méretet, így AIOStreams sem tudja kiolvasni:

https://github.com/Viren070/AIOStreams/blob/6b9ee1c8eaf9fb200c69d083315a58bf4ea54018/packages/core/src/parser/streams.ts#L334-L361