### PR TITLE
Stream közbeni adatbázis zárolás megszüntetése

### DIFF
--- a/server/app/common/async_utils.py
+++ b/server/app/common/async_utils.py
@@ -1,0 +1,16 @@
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+_background_tasks: set[asyncio.Task[Any]] = set()
+
+
+def fire_and_forget(coroutine: Coroutine[Any, Any, Any]) -> None:
+    """
+    Elindít egy coroutine-t a háttérben (fire-and-forget).
+    Megóvja a Task objektumot attól, hogy a Python Garbage Collector
+    megsemmisítse futás közben, ha senki sem várja meg (await) az eredményét.
+    """
+    task = asyncio.create_task(coroutine)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)

--- a/server/app/modules/relay/service.py
+++ b/server/app/modules/relay/service.py
@@ -135,27 +135,11 @@ class RelayService:
         ]
 
     def get_active_streams(self) -> list[Stream]:
-        # Az add_torrent külön thread-en is futhat (asyncio.to_thread), ezért
-        # másolaton iterálunk: enélkül "dictionary changed size during iteration"
-        # hibát kapnánk.
         streams = []
         for torrent in list(self._torrents.values()):
             for file in list(torrent.files.values()):
                 streams.extend(list(file.streams.values()))
         return streams
-
-    def _get_torrents(
-        self,
-    ) -> list[libtorrent.torrent_handle]:
-        torrent_handlers = self._libtorrent_session.get_torrents()
-
-        valid_torrent_handlers = [
-            torrent_handler
-            for torrent_handler in torrent_handlers
-            if torrent_handler.is_valid()
-        ]
-
-        return valid_torrent_handlers
 
     def get_torrent_file(self, info_hash: str, file_index: int) -> File:
         sha1_info_hash = self._parse_info_hash(info_hash)
@@ -272,17 +256,6 @@ class RelayService:
 
         return relay_torrent
 
-    def _get_torrent(
-        self,
-        info_hash: libtorrent.sha1_hash,
-    ) -> libtorrent.torrent_handle | None:
-        torrent_handle = self._libtorrent_session.find_torrent(info_hash)
-
-        if not torrent_handle.is_valid():
-            return None
-
-        return torrent_handle
-
     def delete_torrent(
         self,
         info_hash: str,
@@ -395,3 +368,27 @@ class RelayService:
     ) -> libtorrent.sha1_hash:
         info_hash = libtorrent.sha1_hash(bytes.fromhex(info_hash_str))
         return info_hash
+
+    def _get_torrents(
+        self,
+    ) -> list[libtorrent.torrent_handle]:
+        torrent_handlers = self._libtorrent_session.get_torrents()
+
+        valid_torrent_handlers = [
+            torrent_handler
+            for torrent_handler in torrent_handlers
+            if torrent_handler.is_valid()
+        ]
+
+        return valid_torrent_handlers
+
+    def _get_torrent(
+        self,
+        info_hash: libtorrent.sha1_hash,
+    ) -> libtorrent.torrent_handle | None:
+        torrent_handle = self._libtorrent_session.find_torrent(info_hash)
+
+        if not torrent_handle.is_valid():
+            return None
+
+        return torrent_handle

--- a/server/app/modules/relay/service.py
+++ b/server/app/modules/relay/service.py
@@ -135,9 +135,12 @@ class RelayService:
         ]
 
     def get_active_streams(self) -> list[Stream]:
+        # Az add_torrent külön thread-en is futhat (asyncio.to_thread), ezért
+        # másolaton iterálunk: enélkül "dictionary changed size during iteration"
+        # hibát kapnánk.
         streams = []
-        for torrent in self._torrents.values():
-            for file in torrent.files.values():
+        for torrent in list(self._torrents.values()):
+            for file in list(torrent.files.values()):
                 streams.extend(list(file.streams.values()))
         return streams
 
@@ -156,7 +159,14 @@ class RelayService:
 
     def get_torrent_file(self, info_hash: str, file_index: int) -> File:
         sha1_info_hash = self._parse_info_hash(info_hash)
-        file = self._torrents[sha1_info_hash].files[file_index]
+
+        torrent = self._torrents.get(sha1_info_hash)
+        if torrent is None:
+            raise HTTPException(404, f'"{info_hash}" torrent nem található.')
+
+        file = torrent.files.get(file_index)
+        if file is None:
+            raise HTTPException(400, "Érvénytelen fájl index.")
 
         return file
 
@@ -287,7 +297,9 @@ class RelayService:
         if torrent_handle is None:
             return False
 
-        del self._torrents[info_hash]
+        # A libtorrent session előbb kapja meg a torrentet, mint a _torrents dict
+        # (és az add_torrent külön thread-en is futhat), ezért a hiányzó kulcs nem hiba.
+        self._torrents.pop(info_hash, None)
 
         self._libtorrent_session.remove_torrent(
             torrent_handle,

--- a/server/app/modules/stream/dependencies.py
+++ b/server/app/modules/stream/dependencies.py
@@ -6,9 +6,6 @@ from sqlalchemy.orm import Session
 
 from app.common.database import get_db
 from app.modules.indexers.dependencies import create_indexers_service
-from app.modules.playback_histories.dependencies import (
-    create_playback_histories_service,
-)
 from app.modules.relay.dependencies import get_relay_service
 from app.modules.stream.schemas import StreamToken
 from app.modules.stream.service import StreamService
@@ -22,14 +19,12 @@ def create_stream_service(db: Session) -> StreamService:
     indexers_service = create_indexers_service(db)
     torrent_files_service = create_torrent_files_service(db)
     relay_service = get_relay_service()
-    playback_histories_service = create_playback_histories_service(db)
 
     return StreamService(
         torrents_service=torrents_service,
         indexers_service=indexers_service,
         torrent_files_service=torrent_files_service,
         relay_service=relay_service,
-        playback_histories_service=playback_histories_service,
     )
 
 

--- a/server/app/modules/stream/dependencies.py
+++ b/server/app/modules/stream/dependencies.py
@@ -10,7 +10,10 @@ from app.modules.relay.dependencies import get_relay_service
 from app.modules.stream.schemas import StreamToken
 from app.modules.stream.service import StreamService
 from app.modules.stream.utils.stream_token import parse_stream_token
-from app.modules.torrent_files.dependencies import create_torrent_files_service
+from app.modules.torrent_files.dependencies import (
+    create_isolated_torrent_files_service,
+    create_torrent_files_service,
+)
 from app.modules.torrents.dependencies import create_torrents_service
 
 
@@ -20,11 +23,14 @@ def create_stream_service(db: Session) -> StreamService:
     torrent_files_service = create_torrent_files_service(db)
     relay_service = get_relay_service()
 
+    isolated_torrent_files_service = create_isolated_torrent_files_service()
+
     return StreamService(
         torrents_service=torrents_service,
         indexers_service=indexers_service,
         torrent_files_service=torrent_files_service,
         relay_service=relay_service,
+        isolated_torrent_files_service=isolated_torrent_files_service,
     )
 
 

--- a/server/app/modules/stream/router.py
+++ b/server/app/modules/stream/router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Annotated
 
 import content_types
@@ -54,7 +55,7 @@ async def stream(
 
     with isolated_db_session() as local_db:
         auth_service = create_auth_service(local_db)
-        user = auth_service.verify_api_key(api_key=api_key)
+        user = await asyncio.to_thread(auth_service.verify_api_key, api_key=api_key)
 
         playbacks_service = create_playbacks_service(
             relay_service=get_relay_service(),

--- a/server/app/modules/stream/router.py
+++ b/server/app/modules/stream/router.py
@@ -55,7 +55,10 @@ async def stream(
 
     with isolated_db_session() as local_db:
         auth_service = create_auth_service(local_db)
-        user = await asyncio.to_thread(auth_service.verify_api_key, api_key=api_key)
+        user = await asyncio.to_thread(
+            auth_service.verify_api_key,
+            api_key=api_key,
+        )
 
         playbacks_service = create_playbacks_service(
             relay_service=get_relay_service(),

--- a/server/app/modules/stream/service.py
+++ b/server/app/modules/stream/service.py
@@ -1,4 +1,5 @@
-import libtorrent as libtorrent
+import asyncio
+
 from fastapi import HTTPException
 
 from app.common.database import isolated_db_session
@@ -6,21 +7,26 @@ from app.common.keyed_lock import KeyedLock
 from app.common.logger import logger
 from app.common.schemas.internal import ImdbInfo
 from app.modules.indexers.service import IndexersService
+from app.modules.playback_histories.dependencies import (
+    create_playback_histories_service,
+)
 from app.modules.playback_histories.schemas.internal import (
     PlaybackHistoryClientInfo,
     PlaybackHistoryCreate,
 )
-from app.modules.playback_histories.service import PlaybackHistoriesService
 from app.modules.relay.entities import File
 from app.modules.relay.service import RelayService
 from app.modules.stream.schemas import (
     ParsedRangeHeader,
     StreamToken,
 )
-from app.modules.torrent_files.dependencies import create_torrent_files_service
 from app.modules.torrent_files.models import TorrentFileModel
 from app.modules.torrent_files.schemas import TorrentFileIdentifier
-from app.modules.torrent_files.service import TorrentFilesService
+from app.modules.torrent_files.service import (
+    TorrentFilesService,
+    create_isolated,
+    touch_isolated,
+)
 from app.modules.torrents.dependencies import (
     create_torrents_service,
 )
@@ -38,13 +44,11 @@ class StreamService:
         torrent_files_service: TorrentFilesService,
         indexers_service: IndexersService,
         relay_service: RelayService,
-        playback_histories_service: PlaybackHistoriesService,
     ):
         self._torrents_service = torrents_service
         self._torrent_files_service = torrent_files_service
         self._indexers_service = indexers_service
         self._relay_service = relay_service
-        self._playback_histories_service = playback_histories_service
 
     async def prepare_for_stream(
         self,
@@ -53,22 +57,23 @@ class StreamService:
         torrent_id: str,
         file_index: int,
     ) -> tuple[ParsedRangeHeader, File]:
+        # A touch-ot nem védi a torrent lock: ha azon belül maradna, minden range
+        # kérés sorban állna miatta.
+        await asyncio.to_thread(
+            touch_isolated,
+            TorrentFileIdentifier(indexer_id=indexer_id, torrent_id=torrent_id),
+        )
+
         async with torrent_locks(f"{indexer_id}:{torrent_id}"):
-            torrent_with_relay: TorrentWithRelay | None = (
-                self._torrents_service.find_by_id(
-                    indexer_id=indexer_id,
-                    torrent_id=torrent_id,
-                )
+            torrent_with_relay: TorrentWithRelay | None = await asyncio.to_thread(
+                self._torrents_service.find_by_id,
+                indexer_id=indexer_id,
+                torrent_id=torrent_id,
             )
 
-            with isolated_db_session() as local_db:
-                local_torrent_files_service = create_torrent_files_service(local_db)
-                local_torrent_files_service.touch(
-                    TorrentFileIdentifier(indexer_id=indexer_id, torrent_id=torrent_id)
-                )
-
             if torrent_with_relay is None:
-                torrent_file = self._torrent_files_service.find_by_id(
+                torrent_file = await asyncio.to_thread(
+                    self._torrent_files_service.find_by_id,
                     indexer_id=indexer_id,
                     torrent_id=torrent_id,
                 )
@@ -87,22 +92,18 @@ class StreamService:
                         )
                     )
 
-                    with isolated_db_session() as local_db:
-                        local_torrent_files_service = create_torrent_files_service(
-                            local_db
-                        )
-                        torrent_file = local_torrent_files_service.create(
-                            indexer_id=indexer_id,
-                            torrent_id=torrent_id,
-                            torrent_bytes=downloaded_torrent_file.torrent_bytes,
-                        )
-
-                with isolated_db_session() as local_db:
-                    self._validate_file(torrent_file, file_index)
-                    local_torrents_service = create_torrents_service(local_db)
-                    torrent_with_relay = (
-                        local_torrents_service.create_from_torrent_file(torrent_file)
+                    torrent_file = await asyncio.to_thread(
+                        create_isolated,
+                        indexer_id=indexer_id,
+                        torrent_id=torrent_id,
+                        torrent_bytes=downloaded_torrent_file.torrent_bytes,
                     )
+
+                torrent_with_relay = await asyncio.to_thread(
+                    self._create_torrent,
+                    torrent_file=torrent_file,
+                    file_index=file_index,
+                )
 
         file = self._relay_service.get_torrent_file(
             info_hash=torrent_with_relay.info_hash,
@@ -126,7 +127,8 @@ class StreamService:
     ) -> None:
         try:
             async with playback_history_lock(stream_token.playback_id):
-                self._playback_histories_service.get_or_create(
+                await asyncio.to_thread(
+                    self._save_playback_history,
                     PlaybackHistoryCreate(
                         client=client_info,
                         indexer_id=stream_token.indexer_id,
@@ -137,10 +139,29 @@ class StreamService:
                         imdb_info=imdb_info,
                         torrent_name=file.torrent.name,
                         file_name=file.name,
-                    )
+                    ),
                 )
         except Exception as e:
             logger.warning(f"Nem sikerült menteni a lejátszási előzményt: {e}")
+
+    def _save_playback_history(self, payload: PlaybackHistoryCreate) -> None:
+        """Külön session: egy sikertelen írás nem viheti magával a kérés tranzakcióját."""
+        with isolated_db_session() as local_db:
+            create_playback_histories_service(local_db).get_or_create(payload)
+
+    def _create_torrent(
+        self,
+        torrent_file: TorrentFileModel,
+        file_index: int,
+    ) -> TorrentWithRelay:
+        # A validáció nem érinti az adatbázist: hibás fájl index miatt ne nyissunk
+        # feleslegesen tranzakciót.
+        self._validate_file(torrent_file, file_index)
+
+        with isolated_db_session() as local_db:
+            return create_torrents_service(local_db).create_from_torrent_file(
+                torrent_file
+            )
 
     def _validate_file(
         self,

--- a/server/app/modules/stream/service.py
+++ b/server/app/modules/stream/service.py
@@ -36,6 +36,9 @@ from app.modules.torrents.service import TorrentsService
 torrent_locks = KeyedLock()
 playback_history_lock = KeyedLock()
 
+# A háttérben futó touch task-okra kell egy referencia, különben a GC elviheti őket
+_touch_tasks: set[asyncio.Task[None]] = set()
+
 
 class StreamService:
     def __init__(
@@ -57,11 +60,11 @@ class StreamService:
         torrent_id: str,
         file_index: int,
     ) -> tuple[ParsedRangeHeader, File]:
-        # A touch-ot nem védi a torrent lock: ha azon belül maradna, minden range
-        # kérés sorban állna miatta.
-        await asyncio.to_thread(
-            touch_isolated,
-            TorrentFileIdentifier(indexer_id=indexer_id, torrent_id=torrent_id),
+        # A touch csak egy LRU időbélyeg, a lejátszás nem függ tőle: nem várunk rá.
+        # Ha zárolt az adatbázis, a thread végigüli a 10 mp-es busy timeoutot,
+        # a range kérés viszont ettől függetlenül megy tovább.
+        self._touch_in_background(
+            TorrentFileIdentifier(indexer_id=indexer_id, torrent_id=torrent_id)
         )
 
         async with torrent_locks(f"{indexer_id}:{torrent_id}"):
@@ -143,6 +146,11 @@ class StreamService:
                 )
         except Exception as e:
             logger.warning(f"Nem sikerült menteni a lejátszási előzményt: {e}")
+
+    def _touch_in_background(self, identifier: TorrentFileIdentifier) -> None:
+        task = asyncio.create_task(asyncio.to_thread(touch_isolated, identifier))
+        _touch_tasks.add(task)
+        task.add_done_callback(_touch_tasks.discard)
 
     def _save_playback_history(self, payload: PlaybackHistoryCreate) -> None:
         """Külön session: egy sikertelen írás nem viheti magával a kérés tranzakcióját."""

--- a/server/app/modules/stream/service.py
+++ b/server/app/modules/stream/service.py
@@ -20,13 +20,10 @@ from app.modules.stream.schemas import (
     ParsedRangeHeader,
     StreamToken,
 )
+from app.modules.torrent_files.isolated_service import IsolatedTorrentFilesService
 from app.modules.torrent_files.models import TorrentFileModel
 from app.modules.torrent_files.schemas import TorrentFileIdentifier
-from app.modules.torrent_files.service import (
-    TorrentFilesService,
-    create_isolated,
-    touch_isolated,
-)
+from app.modules.torrent_files.service import TorrentFilesService
 from app.modules.torrents.dependencies import (
     create_torrents_service,
 )
@@ -36,9 +33,6 @@ from app.modules.torrents.service import TorrentsService
 torrent_locks = KeyedLock()
 playback_history_lock = KeyedLock()
 
-# A háttérben futó touch task-okra kell egy referencia, különben a GC elviheti őket
-_touch_tasks: set[asyncio.Task[None]] = set()
-
 
 class StreamService:
     def __init__(
@@ -47,11 +41,13 @@ class StreamService:
         torrent_files_service: TorrentFilesService,
         indexers_service: IndexersService,
         relay_service: RelayService,
+        isolated_torrent_files_service: IsolatedTorrentFilesService,
     ):
         self._torrents_service = torrents_service
         self._torrent_files_service = torrent_files_service
         self._indexers_service = indexers_service
         self._relay_service = relay_service
+        self._isolated_torrent_files_service = isolated_torrent_files_service
 
     async def prepare_for_stream(
         self,
@@ -60,10 +56,7 @@ class StreamService:
         torrent_id: str,
         file_index: int,
     ) -> tuple[ParsedRangeHeader, File]:
-        # A touch csak egy LRU időbélyeg, a lejátszás nem függ tőle: nem várunk rá.
-        # Ha zárolt az adatbázis, a thread végigüli a 10 mp-es busy timeoutot,
-        # a range kérés viszont ettől függetlenül megy tovább.
-        self._touch_in_background(
+        self._isolated_torrent_files_service.touch(
             TorrentFileIdentifier(indexer_id=indexer_id, torrent_id=torrent_id)
         )
 
@@ -96,7 +89,7 @@ class StreamService:
                     )
 
                     torrent_file = await asyncio.to_thread(
-                        create_isolated,
+                        self._isolated_torrent_files_service.create,
                         indexer_id=indexer_id,
                         torrent_id=torrent_id,
                         torrent_bytes=downloaded_torrent_file.torrent_bytes,
@@ -147,11 +140,6 @@ class StreamService:
         except Exception as e:
             logger.warning(f"Nem sikerült menteni a lejátszási előzményt: {e}")
 
-    def _touch_in_background(self, identifier: TorrentFileIdentifier) -> None:
-        task = asyncio.create_task(asyncio.to_thread(touch_isolated, identifier))
-        _touch_tasks.add(task)
-        task.add_done_callback(_touch_tasks.discard)
-
     def _save_playback_history(self, payload: PlaybackHistoryCreate) -> None:
         """Külön session: egy sikertelen írás nem viheti magával a kérés tranzakcióját."""
         with isolated_db_session() as local_db:
@@ -162,8 +150,6 @@ class StreamService:
         torrent_file: TorrentFileModel,
         file_index: int,
     ) -> TorrentWithRelay:
-        # A validáció nem érinti az adatbázist: hibás fájl index miatt ne nyissunk
-        # feleslegesen tranzakciót.
         self._validate_file(torrent_file, file_index)
 
         with isolated_db_session() as local_db:

--- a/server/app/modules/stremio/catalogs_service.py
+++ b/server/app/modules/stremio/catalogs_service.py
@@ -1,6 +1,6 @@
-from venv import logger
+import asyncio
 
-from app.common.database import db_session
+from app.common.logger import logger
 from app.modules.stremio.constants import (
     SEARCH_ID,
 )
@@ -13,9 +13,8 @@ from app.modules.stremio.schemas import (
     ParsedExtra,
     StremioCatalogResponse,
 )
-from app.modules.torrent_files.dependencies import create_torrent_files_service
 from app.modules.torrent_files.schemas import TorrentFileIdentifier
-from app.modules.torrent_files.service import TorrentFilesService
+from app.modules.torrent_files.service import TorrentFilesService, touch_isolated
 from app.modules.torrent_source_provider.service import TorrentSourceProviderService
 
 
@@ -68,16 +67,16 @@ class StremioCatalogsService:
         torrent_id: str,
     ) -> MetaDetail | None:
 
-        with db_session() as local_db:
-            local_torrent_files_service = create_torrent_files_service(local_db)
-            local_torrent_files_service.touch(
-                TorrentFileIdentifier(
-                    indexer_id=indexer_id,
-                    torrent_id=torrent_id,
-                )
-            )
+        await asyncio.to_thread(
+            touch_isolated,
+            TorrentFileIdentifier(
+                indexer_id=indexer_id,
+                torrent_id=torrent_id,
+            ),
+        )
 
-        torrent_file = self._torrent_files_service.find_by_id(
+        torrent_file = await asyncio.to_thread(
+            self._torrent_files_service.find_by_id,
             indexer_id=indexer_id,
             torrent_id=torrent_id,
         )

--- a/server/app/modules/stremio/catalogs_service.py
+++ b/server/app/modules/stremio/catalogs_service.py
@@ -13,8 +13,9 @@ from app.modules.stremio.schemas import (
     ParsedExtra,
     StremioCatalogResponse,
 )
+from app.modules.torrent_files.isolated_service import IsolatedTorrentFilesService
 from app.modules.torrent_files.schemas import TorrentFileIdentifier
-from app.modules.torrent_files.service import TorrentFilesService, touch_isolated
+from app.modules.torrent_files.service import TorrentFilesService
 from app.modules.torrent_source_provider.service import TorrentSourceProviderService
 
 
@@ -23,9 +24,11 @@ class StremioCatalogsService:
         self,
         torrent_files_service: TorrentFilesService,
         torrent_source_provider_service: TorrentSourceProviderService,
+        isolated_torrent_files_service: IsolatedTorrentFilesService,
     ):
         self._torrent_files_service = torrent_files_service
         self._torrent_source_provider_service = torrent_source_provider_service
+        self._isolated_torrent_files_service = isolated_torrent_files_service
 
     async def get_catalog(
         self,
@@ -67,8 +70,7 @@ class StremioCatalogsService:
         torrent_id: str,
     ) -> MetaDetail | None:
 
-        await asyncio.to_thread(
-            touch_isolated,
+        self._isolated_torrent_files_service.touch(
             TorrentFileIdentifier(
                 indexer_id=indexer_id,
                 torrent_id=torrent_id,

--- a/server/app/modules/stremio/dependencies.py
+++ b/server/app/modules/stremio/dependencies.py
@@ -13,7 +13,10 @@ from app.modules.stremio.schemas import (
 )
 from app.modules.stremio.service import StremioService
 from app.modules.stremio.utils import parse_catalog_id, parse_extra, parse_stream_id
-from app.modules.torrent_files.dependencies import create_torrent_files_service
+from app.modules.torrent_files.dependencies import (
+    create_isolated_torrent_files_service,
+    create_torrent_files_service,
+)
 from app.modules.torrent_source_provider.dependencies import (
     create_torrent_source_provider_service,
 )
@@ -27,10 +30,12 @@ def create_stremio_catalogs_service(
 ) -> StremioCatalogsService:
     torrent_files_service = create_torrent_files_service(db)
     torrent_source_provider_service = create_torrent_source_provider_service(db)
+    isolated_torrent_files_service = create_isolated_torrent_files_service()
 
     return StremioCatalogsService(
         torrent_files_service=torrent_files_service,
         torrent_source_provider_service=torrent_source_provider_service,
+        isolated_torrent_files_service=isolated_torrent_files_service,
     )
 
 

--- a/server/app/modules/torrent_files/dependencies.py
+++ b/server/app/modules/torrent_files/dependencies.py
@@ -4,6 +4,7 @@ from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from app.common.database import get_db
+from app.modules.torrent_files.isolated_service import IsolatedTorrentFilesService
 from app.modules.torrent_files.repository import TorrentFilesRepository
 from app.modules.torrent_files.service import TorrentFilesService
 
@@ -17,3 +18,11 @@ def get_torrent_files_service(
     db: Annotated[Session, Depends(get_db)],
 ) -> TorrentFilesService:
     return create_torrent_files_service(db)
+
+
+def create_isolated_torrent_files_service() -> IsolatedTorrentFilesService:
+    return IsolatedTorrentFilesService()
+
+
+def get_isolated_torrent_files_service() -> IsolatedTorrentFilesService:
+    return create_isolated_torrent_files_service()

--- a/server/app/modules/torrent_files/isolated_service.py
+++ b/server/app/modules/torrent_files/isolated_service.py
@@ -1,0 +1,56 @@
+import asyncio
+
+from fastapi import HTTPException
+
+from app.common.async_utils import fire_and_forget
+from app.common.database import isolated_db_session
+from app.common.logger import logger
+from app.modules.torrent_files.models import TorrentFileModel
+from app.modules.torrent_files.repository import TorrentFilesRepository
+from app.modules.torrent_files.schemas import TorrentFileIdentifier
+
+
+class IsolatedTorrentFilesService:
+    """Service elszigetelt adatbázis tranzakciókhoz"""
+
+    def touch(
+        self, identifiers: TorrentFileIdentifier | list[TorrentFileIdentifier]
+    ) -> None:
+        """Azonnal elindítja a touch-ot a háttérben, de nem várja meg az eredményét."""
+        fire_and_forget(asyncio.to_thread(self._touch, identifiers))
+
+    def create(
+        self, indexer_id: str, torrent_id: str, torrent_bytes: bytes
+    ) -> TorrentFileModel:
+        """Elmenti a .torrent fájlt, rövid életű session-ben."""
+        with isolated_db_session() as local_db:
+            repo = TorrentFilesRepository(local_db)
+
+            torrent_file = repo.find_by_id(
+                indexer_id=indexer_id,
+                torrent_id=torrent_id,
+            )
+
+            if torrent_file:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Már létezik torrent a gyorsítótárban: {indexer_id} - {torrent_id}",
+                )
+
+            return repo.create(
+                TorrentFileModel(
+                    indexer_id=indexer_id,
+                    torrent_id=torrent_id,
+                    torrent_bytes=torrent_bytes,
+                )
+            )
+
+    def _touch(
+        self, identifiers: TorrentFileIdentifier | list[TorrentFileIdentifier]
+    ) -> None:
+        """Frissíti a legutóbbi használati időt (last_used_at) külön, rövid életű session-ben."""
+        try:
+            with isolated_db_session() as local_db:
+                TorrentFilesRepository(local_db).touch(identifiers)
+        except Exception as e:
+            logger.warning(f"Nem sikerült frissíteni a torrent használati idejét: {e}")

--- a/server/app/modules/torrent_files/repository.py
+++ b/server/app/modules/torrent_files/repository.py
@@ -6,8 +6,6 @@ from sqlalchemy.orm import Session, joinedload
 from app.modules.torrent_files.models import TorrentFileModel
 from app.modules.torrent_files.schemas import TorrentFileIdentifier, TorrentFilesFilter
 
-# A lejátszó minden range kérésnél touch-ot hív, a retention viszont napokban mér:
-# ennél frissebb rekordot felesleges újraírni (az SQLite egyszerre egy írót enged).
 TOUCH_THROTTLE = datetime.timedelta(minutes=15)
 
 
@@ -33,7 +31,6 @@ class TorrentFilesRepository:
                 query = query.filter_by(indexer_id=filter.indexer_id)
             if filter.torrent_id:
                 query = query.filter_by(torrent_id=filter.torrent_id)
-            # Üres lista is szűrőnek számít: enélkül az egész tábla visszajönne.
             if filter.identifiers is not None:
                 conditions = [
                     and_(
@@ -102,9 +99,6 @@ class TorrentFilesRepository:
             TorrentFileModel.last_used_at <= now - TOUCH_THROTTLE,
         )
 
-        # Csak a kulcsokat olvassuk (a torrent_bytes blob és a joinedload nélkül),
-        # és csak akkor írunk, ha tényleg van elavult rekord: így a throttle-olt
-        # hívások nem nyitnak írási tranzakciót az SQLite-on.
         has_stale = (
             self.db.query(TorrentFileModel.indexer_id).filter(stale_filter).first()
             is not None

--- a/server/app/modules/torrent_files/repository.py
+++ b/server/app/modules/torrent_files/repository.py
@@ -1,10 +1,14 @@
 import datetime
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, false, or_
 from sqlalchemy.orm import Session, joinedload
 
 from app.modules.torrent_files.models import TorrentFileModel
 from app.modules.torrent_files.schemas import TorrentFileIdentifier, TorrentFilesFilter
+
+# A lejátszó minden range kérésnél touch-ot hív, a retention viszont napokban mér:
+# ennél frissebb rekordot felesleges újraírni (az SQLite egyszerre egy írót enged).
+TOUCH_THROTTLE = datetime.timedelta(minutes=15)
 
 
 class TorrentFilesRepository:
@@ -29,7 +33,8 @@ class TorrentFilesRepository:
                 query = query.filter_by(indexer_id=filter.indexer_id)
             if filter.torrent_id:
                 query = query.filter_by(torrent_id=filter.torrent_id)
-            if filter.identifiers:
+            # Üres lista is szűrőnek számít: enélkül az egész tábla visszajönne.
+            if filter.identifiers is not None:
                 conditions = [
                     and_(
                         TorrentFileModel.indexer_id == identifier.indexer_id,
@@ -37,7 +42,7 @@ class TorrentFilesRepository:
                     )
                     for identifier in filter.identifiers
                 ]
-                query = query.filter(or_(*conditions))
+                query = query.filter(or_(*conditions) if conditions else false())
             if filter.exclude_persisted:
                 query = query.filter(~TorrentFileModel.torrent.has())
 
@@ -83,10 +88,31 @@ class TorrentFilesRepository:
             identifiers if isinstance(identifiers, list) else [identifiers]
         )
 
-        records = self.find_list(TorrentFilesFilter(identifiers=identifiers_list))
+        now = datetime.datetime.now()
+        stale_filter = and_(
+            or_(
+                *[
+                    and_(
+                        TorrentFileModel.indexer_id == identifier.indexer_id,
+                        TorrentFileModel.torrent_id == identifier.torrent_id,
+                    )
+                    for identifier in identifiers_list
+                ]
+            ),
+            TorrentFileModel.last_used_at <= now - TOUCH_THROTTLE,
+        )
 
-        if records:
-            now = datetime.datetime.now()
-            for record in records:
-                record.last_used_at = now
-            self.db.flush()
+        # Csak a kulcsokat olvassuk (a torrent_bytes blob és a joinedload nélkül),
+        # és csak akkor írunk, ha tényleg van elavult rekord: így a throttle-olt
+        # hívások nem nyitnak írási tranzakciót az SQLite-on.
+        has_stale = (
+            self.db.query(TorrentFileModel.indexer_id).filter(stale_filter).first()
+            is not None
+        )
+        if not has_stale:
+            return
+
+        self.db.query(TorrentFileModel).filter(stale_filter).update(
+            {TorrentFileModel.last_used_at: now},
+            synchronize_session=False,
+        )

--- a/server/app/modules/torrent_files/service.py
+++ b/server/app/modules/torrent_files/service.py
@@ -2,44 +2,10 @@ import datetime
 
 from fastapi import HTTPException
 
-from app.common.database import isolated_db_session
 from app.common.logger import logger
 from app.modules.torrent_files.models import TorrentFileModel
 from app.modules.torrent_files.repository import TorrentFilesRepository
-from app.modules.torrent_files.schemas import TorrentFileIdentifier, TorrentFilesFilter
-
-
-def touch_isolated(
-    identifiers: TorrentFileIdentifier | list[TorrentFileIdentifier],
-) -> None:
-    """Frissíti a legutóbbi használati időt (last_used_at) külön, rövid életű session-ben.
-
-    Az SQLite egyszerre egy írót enged, ezért a hibát elnyeljük: egy zárolt
-    adatbázis miatt sem a lejátszás, sem a hívó tranzakciója nem bukhat el.
-    Szinkron adatbázis-hívás, ezért az event loopról thread-re kell tenni.
-    """
-    try:
-        with isolated_db_session() as local_db:
-            TorrentFilesRepository(local_db).touch(identifiers)
-    except Exception as e:
-        logger.warning(f"Nem sikerült frissíteni a torrent használati idejét: {e}")
-
-
-def create_isolated(
-    indexer_id: str,
-    torrent_id: str,
-    torrent_bytes: bytes,
-) -> TorrentFileModel:
-    """Elmenti a .torrent fájl bájtjait külön, rövid életű session-ben.
-
-    Szinkron adatbázis-hívás, ezért az event loopról thread-re kell tenni.
-    """
-    with isolated_db_session() as local_db:
-        return TorrentFilesService(TorrentFilesRepository(local_db)).create(
-            indexer_id=indexer_id,
-            torrent_id=torrent_id,
-            torrent_bytes=torrent_bytes,
-        )
+from app.modules.torrent_files.schemas import TorrentFilesFilter
 
 
 class TorrentFilesService:
@@ -48,32 +14,6 @@ class TorrentFilesService:
         torrent_files_repository: TorrentFilesRepository,
     ):
         self._torrent_files_repository = torrent_files_repository
-
-    def create(
-        self,
-        indexer_id: str,
-        torrent_id: str,
-        torrent_bytes: bytes,
-    ) -> TorrentFileModel:
-        """Elmenti a .torrent fájl bájtjait az adatbázisba."""
-        torrent_file = self.find_by_id(
-            indexer_id=indexer_id,
-            torrent_id=torrent_id,
-        )
-
-        if torrent_file:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Már létezik torrent a gyorsítótárban: {indexer_id} - {torrent_id}",
-            )
-
-        return self._torrent_files_repository.create(
-            TorrentFileModel(
-                indexer_id=indexer_id,
-                torrent_id=torrent_id,
-                torrent_bytes=torrent_bytes,
-            )
-        )
 
     def find_list(
         self, filter: TorrentFilesFilter | None = None

--- a/server/app/modules/torrent_files/service.py
+++ b/server/app/modules/torrent_files/service.py
@@ -2,10 +2,44 @@ import datetime
 
 from fastapi import HTTPException
 
+from app.common.database import isolated_db_session
 from app.common.logger import logger
 from app.modules.torrent_files.models import TorrentFileModel
 from app.modules.torrent_files.repository import TorrentFilesRepository
 from app.modules.torrent_files.schemas import TorrentFileIdentifier, TorrentFilesFilter
+
+
+def touch_isolated(
+    identifiers: TorrentFileIdentifier | list[TorrentFileIdentifier],
+) -> None:
+    """Frissíti a legutóbbi használati időt (last_used_at) külön, rövid életű session-ben.
+
+    Az SQLite egyszerre egy írót enged, ezért a hibát elnyeljük: egy zárolt
+    adatbázis miatt sem a lejátszás, sem a hívó tranzakciója nem bukhat el.
+    Szinkron adatbázis-hívás, ezért az event loopról thread-re kell tenni.
+    """
+    try:
+        with isolated_db_session() as local_db:
+            TorrentFilesRepository(local_db).touch(identifiers)
+    except Exception as e:
+        logger.warning(f"Nem sikerült frissíteni a torrent használati idejét: {e}")
+
+
+def create_isolated(
+    indexer_id: str,
+    torrent_id: str,
+    torrent_bytes: bytes,
+) -> TorrentFileModel:
+    """Elmenti a .torrent fájl bájtjait külön, rövid életű session-ben.
+
+    Szinkron adatbázis-hívás, ezért az event loopról thread-re kell tenni.
+    """
+    with isolated_db_session() as local_db:
+        return TorrentFilesService(TorrentFilesRepository(local_db)).create(
+            indexer_id=indexer_id,
+            torrent_id=torrent_id,
+            torrent_bytes=torrent_bytes,
+        )
 
 
 class TorrentFilesService:
@@ -54,13 +88,6 @@ class TorrentFilesService:
 
     def find_by_info_hash(self, info_hash: str) -> TorrentFileModel | None:
         return self._torrent_files_repository.find_by_info_hash(info_hash)
-
-    def touch(
-        self,
-        identifiers: TorrentFileIdentifier | list[TorrentFileIdentifier],
-    ) -> None:
-        """Frissíti a megadott .torrent fájl(ok) legutóbbi használati idejét (last_used_at) az adatbázisban."""
-        self._torrent_files_repository.touch(identifiers)
 
     def get_by_id(self, indexer_id: str, torrent_id: str) -> TorrentFileModel:
         record = self.find_by_id(indexer_id, torrent_id)

--- a/server/app/modules/torrent_source_provider/dependencies.py
+++ b/server/app/modules/torrent_source_provider/dependencies.py
@@ -1,15 +1,20 @@
 from sqlalchemy.orm import Session
 
 from app.modules.indexers.dependencies import create_indexers_service
-from app.modules.torrent_files.dependencies import create_torrent_files_service
+from app.modules.torrent_files.dependencies import (
+    create_isolated_torrent_files_service,
+    create_torrent_files_service,
+)
 from app.modules.torrent_source_provider.service import TorrentSourceProviderService
 
 
 def create_torrent_source_provider_service(db: Session) -> TorrentSourceProviderService:
     indexers_service = create_indexers_service(db)
     torrent_files_service = create_torrent_files_service(db)
+    isolated_torrent_files_service = create_isolated_torrent_files_service()
 
     return TorrentSourceProviderService(
         indexers_service=indexers_service,
         torrent_files_service=torrent_files_service,
+        isolated_torrent_files_service=isolated_torrent_files_service,
     )

--- a/server/app/modules/torrent_source_provider/service.py
+++ b/server/app/modules/torrent_source_provider/service.py
@@ -7,13 +7,10 @@ from app.common.logger import logger
 from app.modules.indexers.schemas.internal import IndexerTorrent
 from app.modules.indexers.service import IndexersService
 from app.modules.torrent_files.exceptions import InvalidTorrentFileException
+from app.modules.torrent_files.isolated_service import IsolatedTorrentFilesService
 from app.modules.torrent_files.models import TorrentFileModel
 from app.modules.torrent_files.schemas import TorrentFileIdentifier, TorrentFilesFilter
-from app.modules.torrent_files.service import (
-    TorrentFilesService,
-    create_isolated,
-    touch_isolated,
-)
+from app.modules.torrent_files.service import TorrentFilesService
 from app.modules.torrent_source_provider.schemas import TorrentSource
 
 _torrent_provider_locks = KeyedLock()
@@ -29,10 +26,11 @@ class TorrentSourceProviderService:
         self,
         indexers_service: IndexersService,
         torrent_files_service: TorrentFilesService,
+        isolated_torrent_files_service: IsolatedTorrentFilesService,
     ):
         self._indexers_service = indexers_service
         self._torrent_files_service = torrent_files_service
-        self._db_lock = asyncio.Lock()
+        self._isolated_torrent_files_service = isolated_torrent_files_service
 
     async def find_by_imdb_id(
         self,
@@ -154,10 +152,7 @@ class TorrentSourceProviderService:
             filter=TorrentFilesFilter(identifiers=torrent_file_ids),
         )
 
-        await asyncio.to_thread(
-            touch_isolated,
-            torrent_file_ids,
-        )
+        self._isolated_torrent_files_service.touch(torrent_file_ids)
 
         current_torrent_files_map: dict[tuple[str, str], TorrentFileModel] = {
             (
@@ -226,12 +221,11 @@ class TorrentSourceProviderService:
         async with _torrent_provider_locks(
             f"{indexer_torrent.indexer_account.indexer_id}:{indexer_torrent.torrent_id}"
         ):
-            async with self._db_lock:
-                existing_torrent = await asyncio.to_thread(
-                    self._torrent_files_service.find_by_id,
-                    indexer_id=indexer_torrent.indexer_account.indexer_id,
-                    torrent_id=indexer_torrent.torrent_id,
-                )
+            existing_torrent = await asyncio.to_thread(
+                self._torrent_files_service.find_by_id,
+                indexer_id=indexer_torrent.indexer_account.indexer_id,
+                torrent_id=indexer_torrent.torrent_id,
+            )
             if existing_torrent:
                 return existing_torrent
 
@@ -242,13 +236,12 @@ class TorrentSourceProviderService:
                     indexer_torrent.download_url,
                 )
 
-                async with self._db_lock:
-                    return await asyncio.to_thread(
-                        create_isolated,
-                        indexer_id=downloaded_torrent_file.indexer_id,
-                        torrent_id=downloaded_torrent_file.torrent_id,
-                        torrent_bytes=downloaded_torrent_file.torrent_bytes,
-                    )
+                return await asyncio.to_thread(
+                    self._isolated_torrent_files_service.create,
+                    indexer_id=downloaded_torrent_file.indexer_id,
+                    torrent_id=downloaded_torrent_file.torrent_id,
+                    torrent_bytes=downloaded_torrent_file.torrent_bytes,
+                )
             except InvalidTorrentFileException:
                 logger.warning(
                     f"⚠️ Érvénytelen torrent fájl átugorva: indexer: {indexer_torrent.indexer_account.indexer_id}, torrent_id: {indexer_torrent.torrent_id}"

--- a/server/app/modules/torrent_source_provider/service.py
+++ b/server/app/modules/torrent_source_provider/service.py
@@ -2,16 +2,18 @@ import asyncio
 from collections.abc import Awaitable
 from typing import cast, overload
 
-from app.common.database import isolated_db_session
 from app.common.keyed_lock import KeyedLock
 from app.common.logger import logger
 from app.modules.indexers.schemas.internal import IndexerTorrent
 from app.modules.indexers.service import IndexersService
-from app.modules.torrent_files.dependencies import create_torrent_files_service
 from app.modules.torrent_files.exceptions import InvalidTorrentFileException
 from app.modules.torrent_files.models import TorrentFileModel
 from app.modules.torrent_files.schemas import TorrentFileIdentifier, TorrentFilesFilter
-from app.modules.torrent_files.service import TorrentFilesService
+from app.modules.torrent_files.service import (
+    TorrentFilesService,
+    create_isolated,
+    touch_isolated,
+)
 from app.modules.torrent_source_provider.schemas import TorrentSource
 
 _torrent_provider_locks = KeyedLock()
@@ -120,29 +122,6 @@ class TorrentSourceProviderService:
 
         return torrent_file
 
-    def _touch_isolated(
-        self,
-        identifiers: TorrentFileIdentifier | list[TorrentFileIdentifier],
-    ) -> None:
-        with isolated_db_session() as local_db:
-            local_torrent_files_service = create_torrent_files_service(local_db)
-            local_torrent_files_service.touch(identifiers)
-
-    def _create_isolated(
-        self,
-        indexer_id: str,
-        torrent_id: str,
-        torrent_bytes: bytes,
-    ) -> TorrentFileModel:
-        with isolated_db_session() as local_db:
-            local_torrent_files_service = create_torrent_files_service(local_db)
-            torrent_file = local_torrent_files_service.create(
-                indexer_id=indexer_id,
-                torrent_id=torrent_id,
-                torrent_bytes=torrent_bytes,
-            )
-            return torrent_file
-
     @overload
     async def _sync_torrent_files(
         self,
@@ -176,7 +155,7 @@ class TorrentSourceProviderService:
         )
 
         await asyncio.to_thread(
-            self._touch_isolated,
+            touch_isolated,
             torrent_file_ids,
         )
 
@@ -265,7 +244,7 @@ class TorrentSourceProviderService:
 
                 async with self._db_lock:
                     return await asyncio.to_thread(
-                        self._create_isolated,
+                        create_isolated,
                         indexer_id=downloaded_torrent_file.indexer_id,
                         torrent_id=downloaded_torrent_file.torrent_id,
                         torrent_bytes=downloaded_torrent_file.torrent_bytes,

--- a/server/tests/test_torrent_files_touch.py
+++ b/server/tests/test_torrent_files_touch.py
@@ -1,0 +1,125 @@
+import datetime
+import sqlite3
+import threading
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.common.database import Base, connect_args
+from app.modules.torrent_files.repository import TOUCH_THROTTLE, TorrentFilesRepository
+from app.modules.torrent_files.schemas import TorrentFileIdentifier
+
+IDENTIFIER = TorrentFileIdentifier(indexer_id="ncore", torrent_id="3374373")
+
+
+@pytest.fixture
+def session_factory(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path}/app.db", connect_args=connect_args)
+    Base.metadata.create_all(engine)
+    yield sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    engine.dispose()
+
+
+def _as_sqlite_text(value: datetime.datetime) -> str:
+    """A sqlite3 alapértelmezett datetime adaptere 3.12 óta elavult, ezért mi alakítjuk át."""
+    return value.isoformat(sep=" ")
+
+
+def seed(session_factory, last_used_at: datetime.datetime) -> None:
+    with session_factory() as db:
+        db.execute(text("PRAGMA foreign_keys=OFF"))
+        db.execute(
+            text(
+                "INSERT INTO indexer_accounts (indexer_id, username, password,"
+                " hit_and_run, keep_seed_seconds, download_full_torrent, created_at,"
+                " updated_at) VALUES ('ncore', 'u', 'p', 0, 0, 0, :now, :now)"
+            ),
+            {"now": _as_sqlite_text(last_used_at)},
+        )
+        db.execute(
+            text(
+                "INSERT INTO torrent_files (indexer_id, torrent_id, info_hash,"
+                " torrent_bytes, last_used_at, created_at)"
+                " VALUES ('ncore', '3374373', 'hash', X'00', :last_used_at, :now)"
+            ),
+            {
+                "last_used_at": _as_sqlite_text(last_used_at),
+                "now": _as_sqlite_text(last_used_at),
+            },
+        )
+        db.commit()
+
+
+def read_last_used_at(session_factory) -> datetime.datetime:
+    with session_factory() as db:
+        value = db.execute(text("SELECT last_used_at FROM torrent_files")).scalar_one()
+    return datetime.datetime.fromisoformat(value)
+
+
+def test_touch_updates_a_stale_record(session_factory):
+    stale = datetime.datetime.now() - TOUCH_THROTTLE - datetime.timedelta(minutes=1)
+    seed(session_factory, stale)
+
+    with session_factory() as db:
+        TorrentFilesRepository(db).touch(IDENTIFIER)
+        db.commit()
+
+    assert read_last_used_at(session_factory) > stale
+
+
+def test_touch_skips_a_recently_used_record(session_factory):
+    """A lejátszó range kérésenként hív touch-ot: enélkül minden kérés írás lenne."""
+    recent = datetime.datetime.now() - TOUCH_THROTTLE / 2
+    seed(session_factory, recent)
+
+    with session_factory() as db:
+        TorrentFilesRepository(db).touch(IDENTIFIER)
+        db.commit()
+
+    assert read_last_used_at(session_factory) == recent
+
+
+def test_touch_does_not_write_while_another_connection_holds_the_write_lock(
+    session_factory, tmp_path
+):
+    """Throttle esetén a zárolt adatbázis sem okoz hibát."""
+    recent = datetime.datetime.now() - TOUCH_THROTTLE / 2
+    seed(session_factory, recent)
+
+    holder = sqlite3.connect(f"{tmp_path}/app.db", timeout=10.0, isolation_level=None)
+    holder.execute("BEGIN IMMEDIATE")
+    try:
+        with session_factory() as db:
+            TorrentFilesRepository(db).touch(IDENTIFIER)
+            db.commit()
+    finally:
+        holder.rollback()
+        holder.close()
+
+    assert read_last_used_at(session_factory) == recent
+
+
+def test_touch_is_thread_safe_for_offloaded_calls(session_factory):
+    """A stream útvonal külön thread-en hívja: párhuzamosan sem dobhat hibát."""
+    stale = datetime.datetime.now() - TOUCH_THROTTLE - datetime.timedelta(minutes=1)
+    seed(session_factory, stale)
+
+    errors: list[Exception] = []
+
+    def worker():
+        try:
+            with session_factory() as db:
+                TorrentFilesRepository(db).touch(IDENTIFIER)
+                db.commit()
+        except Exception as error:
+            errors.append(error)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert read_last_used_at(session_factory) > stale


### PR DESCRIPTION
Hali!

Ubuntu-n, HDD-re streamelve néztem egy 720p filmet, és lejátszás közben folyton bufferelt. Közben ez ismétlődött a logban:

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) database is locked
[SQL: UPDATE torrent_files SET last_used_at=? WHERE torrent_files.indexer_id = ? AND torrent_files.torrent_id = ?]
```

Kiderült, hogy a kettő ugyanaz a bug. A `/stream` `async def`, de a benne futó SQLite hívások szinkronok, SQLite-ból viszont egyszerre csak egy író lehet (a WAL csak az olvasókat engedi el). Szóval ha a `touch()` UPDATE-je belefut egy másik íróba, akkor a 10 másodperces busy timeoutot az event loopon üli végig. Addig viszont egyik stream sem kap chunkot, mert a `Stream._stream_inner` sima async generator, minden chunk a loopon megy ki. Innen jön a bufferelés annál is, aki nem is abban a kérésben ült.

Lemértem uvicorn alatt, 15 másodpercig fogott write lock mellett: `async def` végpontnál 10,15 mp volt a leghosszabb szünet két chunk között egy teljesen független streamnél, threadpoolos `def`-nél 0,12 mp. Lassú író amúgy nem is kell hozzá, elég ha valaki flush után awaitel: a blokkolt toucher megfogja a loopot, így az író nem jut el a commitig, és 0,5 mp-es írásból is 10 mp-es hiba lesz.

```
[async] writer holds the lock for only 0.5s -> /touch OperationalError after 10.04s
[sync ] writer holds the lock for only 0.5s -> /touch ok after 0.46s
```

HDD-n ez pláne fáj, a `touch()` meg range kérésenként ment, streamenként.

Amit csináltam:

- a stream útvonal szinkron DB hívásait `asyncio.to_thread`-re tettem, ugyanúgy ahogy a `torrent_source_provider` már csinálja
- a `touch()` külön session-ben fut és elnyeli a hibát, mert a `last_used_at` frissítése miatt semmiképp ne szálljon el a lejátszás. Emellett 15 percnél gyakrabban nem ír, a retention úgyis napokban méri, és nem is hidratál ORM rekordot (blob + joinedload) csak azért, hogy egy timestampet megnézzen
- a playback history is külön session-be került. Eddig egy sikertelen írás magával vitte a kérés tranzakcióját, az ottani `except` csak papíron védett, mert a `with` blokk commitja utána így is elszállt
- a relay `_torrents` dict-jén másolaton iterálunk, mert az `add_torrent` már thread-en is futhat
- menet közben találtam még kettőt: a `find_list` az üres `identifiers` listát nem vette szűrőnek, szóval minden üres találatú keresésnél az egész `torrent_files` tábla visszajött a blobokkal együtt; rossz file indexnél meg bare `KeyError` ment 400 helyett

A hívó oldalán nagyjából ennyi az egész:

```python
# előtte, szinkron session az event loopon
with isolated_db_session() as local_db:
    create_torrent_files_service(local_db).touch(identifier)

# utána, thread-en, es nem is varunk ra
self._touch_in_background(identifier)
```

Teszt: `tests/test_torrent_files_touch.py`, throttle + zárolt DB + párhuzamos hívások. Ugyanazt a scenariót lefuttatva az éles kódon a `/touch` már 200-zal tér vissza 500 helyett, a másik stream max szünete 0,12 mp, a throttle ablakon belüli második hívás meg nem ír semmit.

Végül felraktam az egészet egy éles appra is, hogy ne csak szintetikus mérés legyen: temp data dirbe felhúzva az igazi boot szekvenciát (migráció, default settings, lifespan, libtorrent session), egy valódi 12 MB-os .torrent-tel, amit a lemezről seedel, és az igazi `/api/{api_key}/stream/{token}` route-on lekérve. Range kérés és seek is bájtazonos választ ad. A régi kódra visszaállva ugyanaz a szkript reprodukálja a hibát:

|  | main | ez a PR |
|---|---|---|
| stream kérés, miközben áll egy write lock | HTTP 500, 10,02 mp | HTTP 206, bájtazonos, 0,02 mp |
| `/api/health` ugyanekkor (mennyire él az event loop) | leglassabb 10,02 mp | leglassabb 0,01 mp |

A második commit is ebből jött: a válasz már jó volt, de a kérés még mindig 10 másodpercig várt a touch thread-jére, pedig az csak egy LRU időbélyeg. Most háttértaskban megy, a `warning` meg ott marad a logban, ha nem sikerült.

Amihez nem nyúltam: a write lock még mindig ki van adva az `add_torrent` idejére, de az egy 200 GB-os packnél is csak 13-24 ms, és az early commit orphan rekordot hagyna. A `TOUCH_THROTTLE` naiv local time-mal számol, szóval DST visszaálláskor kb. egy órára kiesik a touch, ezt inkább külön issue-nak hagynám.

Amit viszont nem sikerült megfognom: hogy nálad pontosan melyik író ült a locko(ko)n 10 másodpercig. A javítás ettől függetlenül megszünteti a tünetet, de ha érdekel, tudok írni egy ideiglenes logolást, ami kiírja a hosszú write tranzakciókat.

Kapcsolódik: #251, ez ugyanannak a hibának a második köre.
