### PR TITLE
display 3D label in stream name

### DIFF
--- a/server/app/modules/media_attributes/seeds.py
+++ b/server/app/modules/media_attributes/seeds.py
@@ -296,6 +296,15 @@ DEFAULT_ATTRIBUTES = [
         is_preferable=False,
         show_in_details=True,
     ),
+    MediaAttributeModel(
+        id=MediaAttributeKey.THREE_D,
+        name="3D",
+        preference_id=PreferenceKey.EDITION,
+        pattern=r"\b(3d|hsbs|hou|half[-_. ]?(?:sbs|ou))\b",
+        short_name="3D",
+        is_preferable=False,
+        show_in_details=True,
+    ),
     # Audio Qualities
     MediaAttributeModel(
         id=MediaAttributeKey.TRUEHD,
@@ -382,15 +391,5 @@ DEFAULT_ATTRIBUTES = [
         preference_id=PreferenceKey.AUDIO_CHANNELS,
         pattern=r"(2\.0|2ch|stereo)",
         short_name="2.0",
-    ),
-    # Others
-    MediaAttributeModel(
-        id=MediaAttributeKey.THREE_D,
-        name="3D",
-        preference_id=PreferenceKey.EDITION,
-        pattern=r"\b(3d|hsbs|hou|half[-_. ]?(?:sbs|ou))\b",
-        short_name="3D",
-        is_preferable=False,
-        show_in_details=True,
     ),
 ]

--- a/server/app/modules/media_attributes/seeds.py
+++ b/server/app/modules/media_attributes/seeds.py
@@ -387,8 +387,10 @@ DEFAULT_ATTRIBUTES = [
     MediaAttributeModel(
         id=MediaAttributeKey.THREE_D,
         name="3D",
-        preference_id=None,
+        preference_id=PreferenceKey.EDITION,
         pattern=r"\b(3d|hsbs|hou|half[-_. ]?(?:sbs|ou))\b",
         short_name="3D",
+        is_preferable=False,
+        show_in_details=True,
     ),
 ]

--- a/server/app/modules/stremio/schemas.py
+++ b/server/app/modules/stremio/schemas.py
@@ -137,6 +137,7 @@ class BehaviorHints(BaseModel):
     not_web_ready: bool = True
     binge_group: str | None = None
     filename: str | None = None
+    video_size: int | None = None
 
 
 class StremioStream(BaseModel):
@@ -167,6 +168,7 @@ class StremioStream(BaseModel):
                         if isinstance(attr, MediaAttributeModel)
                     ],
                 ),
+                video_size=torrent_stream.file_size,
             ),
         )
 
@@ -236,12 +238,9 @@ class StremioStream(BaseModel):
         if torrent_stream.is_persisted_torrent:
             readable_is_persisted = "⭐"
 
-        is_3d = any(attr.id == "3d" for attr in media_attributes)
-        readable_3d = "🥽 3D" if is_3d else None
-
         name = " | ".join(
             compact(
-                [readable_3d, readable_is_persisted, readable_resolutions, readable_video_qualities]
+                [readable_is_persisted, readable_resolutions, readable_video_qualities]
             )
         )
         description = "\n".join(
@@ -261,6 +260,7 @@ class StremioStream(BaseModel):
             behavior_hints=BehaviorHints(
                 filename=behavior_filename,
                 binge_group=binge_group,
+                video_size=torrent_stream.file_size,
             ),
         )
 

--- a/server/app/modules/stremio/schemas.py
+++ b/server/app/modules/stremio/schemas.py
@@ -137,7 +137,6 @@ class BehaviorHints(BaseModel):
     not_web_ready: bool = True
     binge_group: str | None = None
     filename: str | None = None
-    video_size: int | None = None
 
 
 class StremioStream(BaseModel):
@@ -168,7 +167,6 @@ class StremioStream(BaseModel):
                         if isinstance(attr, MediaAttributeModel)
                     ],
                 ),
-                video_size=torrent_stream.file_size,
             ),
         )
 
@@ -238,9 +236,12 @@ class StremioStream(BaseModel):
         if torrent_stream.is_persisted_torrent:
             readable_is_persisted = "⭐"
 
+        is_3d = any(attr.id == "3d" for attr in media_attributes)
+        readable_3d = "🥽 3D" if is_3d else None
+
         name = " | ".join(
             compact(
-                [readable_is_persisted, readable_resolutions, readable_video_qualities]
+                [readable_3d, readable_is_persisted, readable_resolutions, readable_video_qualities]
             )
         )
         description = "\n".join(
@@ -260,7 +261,6 @@ class StremioStream(BaseModel):
             behavior_hints=BehaviorHints(
                 filename=behavior_filename,
                 binge_group=binge_group,
-                video_size=torrent_stream.file_size,
             ),
         )
 


### PR DESCRIPTION
A stream nevébe bekerül egy 3D jelölés (🥽 3D), ha a torrent 3D-s tartalmat tartalmaz.

## Miért

A 3D torrentek már helyesen voltak felismerve és tárolva a meglévő `THREE_D` attribútumon keresztül (`seeds.py`), de a jelölés soha nem jelent meg a Stremio stream nevében – így nem lehetett megkülönböztetni a 3D streameket a hagyományos streamektől.

## Hogyan

A `StremioStream.from_imdb_torrent_stream` metódusban ellenőrzöm, hogy a feloldott media attribútumok között szerepel-e `id == "3d"`, és ha igen, a stream neve elé kerül a `🥽 3D` jelölés.

A `THREE_D` attribútumnak `preference_id=None` értéke van, ezért a `format_group()` / `_attributes_parser()` soha nem találta meg – a közvetlen id ellenőrzés volt a legegyszerűbb megoldás.